### PR TITLE
Require Course comment

### DIFF
--- a/app/instructionalSupport/studentSupportCallForm/controllers/studentSupportCallFormCtrl.js
+++ b/app/instructionalSupport/studentSupportCallForm/controllers/studentSupportCallFormCtrl.js
@@ -172,6 +172,17 @@ instructionalSupportApp.controller('StudentSupportCallFormCtrl', ['$scope', '$ro
 					return false;
 				}
 
+				if ($scope.view.state.supportCallResponse.requirePreferenceComments == true) {
+					for (var i = 0; i < $scope.view.state.preferences.length; i++) {
+						var preference = $scope.view.state.preferences[i];
+
+						if (preference.comment.length == 0) {
+							$scope.validationError = "You must provide a comment for each preference";
+							return false;
+						}
+					}
+				}
+
 				$scope.validationError = "";
 				return true;
 			};

--- a/app/instructionalSupport/studentSupportCallForm/studentSupportCallForm.css
+++ b/app/instructionalSupport/studentSupportCallForm/studentSupportCallForm.css
@@ -229,3 +229,15 @@ h4, .h4 {
 	font-size: 8pt;
 	color: rgba(44, 126, 161, 0.7);
 }
+
+.preference-comments-ui {
+	cursor: pointer;
+}
+
+.comments-btn i.preference-comment-submitted {
+	color: black;
+}
+
+.comments-btn i.preference-comment-required {
+	color: #e40000;
+}

--- a/app/instructionalSupport/studentSupportCallForm/templates/StudentSupportCallForm.html
+++ b/app/instructionalSupport/studentSupportCallForm/templates/StudentSupportCallForm.html
@@ -124,13 +124,13 @@
 								<div ng-show="view.state.supportCallResponse.collectPreferenceComments" class="comments-btn">
 									<div ng-if="preference.comment.length == 0 && view.state.supportCallResponse.requirePreferenceComments == true" uib-tooltip="Preference comment is required">
 										<div ng-click="openPreferenceCommentModal(preference)"><i class="glyphicon glyphicon-edit preference-comments-ui"
-											ng-class="{'preference-comment-submitted' : preference.comment.length > 0, 'preference-comment-required' : preference.comment.length == 0 && view.state.supportCallResponse.requirePreferenceComments == true }"></i>
+											ng-class="{'preference-comment-submitted' : preference.comment.length > 0 }"></i>
 												<span>Comments...</span>
 										</div>
 									</div>
 									<div ng-if="preference.comment.length != 0 || view.state.supportCallResponse.requirePreferenceComments != true">
 										<div ng-click="openPreferenceCommentModal(preference)"><i class="glyphicon glyphicon-edit preference-comments-ui"
-											ng-class="{'preference-comment-submitted' : preference.comment.length > 0, 'preference-comment-required' : preference.comment.length == 0 && view.state.supportCallResponse.requirePreferenceComments == true }"></i>
+											ng-class="{'preference-comment-submitted' : preference.comment.length > 0 }"></i>
 											<span>Comments...</span>
 										</div>
 									</div>

--- a/app/instructionalSupport/studentSupportCallForm/templates/StudentSupportCallForm.html
+++ b/app/instructionalSupport/studentSupportCallForm/templates/StudentSupportCallForm.html
@@ -122,9 +122,18 @@
 									</div>
 								</div>
 								<div ng-show="view.state.supportCallResponse.collectPreferenceComments" class="comments-btn">
-									<div ng-click="openPreferenceCommentModal(preference)"><i class="glyphicon glyphicon-edit"></i>
-										<span>Comments...</span>
-									</a>
+									<div ng-if="preference.comment.length == 0 && view.state.supportCallResponse.requirePreferenceComments == true" uib-tooltip="Preference comment is required">
+										<div ng-click="openPreferenceCommentModal(preference)"><i class="glyphicon glyphicon-edit preference-comments-ui"
+											ng-class="{'preference-comment-submitted' : preference.comment.length > 0, 'preference-comment-required' : preference.comment.length == 0 && view.state.supportCallResponse.requirePreferenceComments == true }"></i>
+												<span>Comments...</span>
+										</div>
+									</div>
+									<div ng-if="preference.comment.length != 0 || view.state.supportCallResponse.requirePreferenceComments != true">
+										<div ng-click="openPreferenceCommentModal(preference)"><i class="glyphicon glyphicon-edit preference-comments-ui"
+											ng-class="{'preference-comment-submitted' : preference.comment.length > 0, 'preference-comment-required' : preference.comment.length == 0 && view.state.supportCallResponse.requirePreferenceComments == true }"></i>
+											<span>Comments...</span>
+										</div>
+									</div>
 								</div>
 							</li>
 						</ul>

--- a/app/instructionalSupport/supportCallStatus/controllers/ModalAddSupportCallCtrl.js
+++ b/app/instructionalSupport/supportCallStatus/controllers/ModalAddSupportCallCtrl.js
@@ -94,7 +94,17 @@ instructionalSupportApp.controller('ModalAddSupportCallCtrl', this.ModalAddSuppo
 	$scope.toggleCollectPreferenceComments = function () {
 		if ($scope.supportCallConfigData.collectPreferenceComments) {
 			$scope.supportCallConfigData.collectPreferenceComments = false;
+			$scope.supportCallConfigData.requirePreferenceComments = false;
 		} else {
+			$scope.supportCallConfigData.collectPreferenceComments = true;
+		}
+	};
+
+	$scope.toggleRequirePreferenceComments = function () {
+		if ($scope.supportCallConfigData.requirePreferenceComments) {
+			$scope.supportCallConfigData.requirePreferenceComments = false;
+		} else {
+			$scope.supportCallConfigData.requirePreferenceComments = true;
 			$scope.supportCallConfigData.collectPreferenceComments = true;
 		}
 	};

--- a/app/instructionalSupport/supportCallStatus/directives/modalAddSupportCall.js
+++ b/app/instructionalSupport/supportCallStatus/directives/modalAddSupportCall.js
@@ -87,15 +87,6 @@ sharedApp.directive("modalAddSupportCall", this.modalAddSupportCall = function (
 				}
 			};
 
-			scope.toggleRequirePreferenceComments = function () {
-				if (scope.supportCallConfigData.requirePreferenceComments) {
-					scope.supportCallConfigData.requirePreferenceComments = false;
-				} else {
-					scope.supportCallConfigData.requirePreferenceComments = true;
-					scope.supportCallConfigData.collectPreferenceComments = true;
-				}
-			};
-
 			scope.toggleCollectEligibilityConfirmation = function () {
 				if (scope.supportCallConfigData.collectEligibilityConfirmation) {
 					scope.supportCallConfigData.collectEligibilityConfirmation = false;

--- a/app/instructionalSupport/supportCallStatus/directives/modalAddSupportCall.js
+++ b/app/instructionalSupport/supportCallStatus/directives/modalAddSupportCall.js
@@ -87,6 +87,15 @@ sharedApp.directive("modalAddSupportCall", this.modalAddSupportCall = function (
 				}
 			};
 
+			scope.toggleRequirePreferenceComments = function () {
+				if (scope.supportCallConfigData.requirePreferenceComments) {
+					scope.supportCallConfigData.requirePreferenceComments = false;
+				} else {
+					scope.supportCallConfigData.requirePreferenceComments = true;
+					scope.supportCallConfigData.collectPreferenceComments = true;
+				}
+			};
+
 			scope.toggleCollectEligibilityConfirmation = function () {
 				if (scope.supportCallConfigData.collectEligibilityConfirmation) {
 					scope.supportCallConfigData.collectEligibilityConfirmation = false;

--- a/app/instructionalSupport/supportCallStatus/templates/AddSupportCallModal.html
+++ b/app/instructionalSupport/supportCallStatus/templates/AddSupportCallModal.html
@@ -153,6 +153,16 @@
 										</div>
 								</li>
 
+								<li ng-if="supportCallConfigData.mode == 'supportStaff'" role="menuitem" ng-click="toggleRequirePreferenceComments()">
+										<div class="checkbox checkbox-replace color-primary neon-cb-replacement"
+											ng-class="{ 'checked': supportCallConfigData.requirePreferenceComments }">
+											<label class="cb-wrapper">
+												<div class="checked"></div>
+											</label>
+											<label>Require general comments</label>
+										</div>
+								</li>
+
 								<li ng-if="supportCallConfigData.mode == 'supportStaff'" role="menuitem" ng-click="toggleCollectEligibilityConfirmation()">
 										<div class="checkbox checkbox-replace color-primary neon-cb-replacement"
 											ng-class="{ 'checked': supportCallConfigData.collectEligibilityConfirmation }">

--- a/app/instructionalSupport/supportCallStatus/templates/AddSupportCallModal.html
+++ b/app/instructionalSupport/supportCallStatus/templates/AddSupportCallModal.html
@@ -159,7 +159,7 @@
 											<label class="cb-wrapper">
 												<div class="checked"></div>
 											</label>
-											<label>Require general comments</label>
+											<label>Require preference comments</label>
 										</div>
 								</li>
 


### PR DESCRIPTION
On the support call module, When adding a student to the support call, the modal now has an additional configuration option to not only collect, but also require preference comments. These options will auto-set/auto-remove logically.

In the student support call, the form properly validates for the presence of a comment on each preference if it is required, and marks the preference comment red and adds a tooltip if a comment is missing.

Additionally, the preference comment button now is gray when no comment exists, and black when one is present.