### PR TITLE
CoursesView: bugfix Cannot set property 'sectionIds'

### DIFF
--- a/app/course/services/courseStateService.js
+++ b/app/course/services/courseStateService.js
@@ -263,7 +263,12 @@ courseApp.service('courseStateService', function ($rootScope, $log, Course, Term
 					sectionGroups.list[action.payload.sectionGroup.id].plannedSeats = action.payload.sectionGroup.plannedSeats;
 					return sectionGroups;
 				case FETCH_SECTIONS:
-					sectionGroups.list[action.payload.sectionGroup.id].sectionIds = action.payload.sections
+					var sectionGroup = sectionGroups.list[action.payload.sectionGroup.id];
+					if (!sectionGroup) {
+						return sectionGroups;
+					}
+
+					sectionGroup.sectionIds = action.payload.sections
 						.sort(function (sectionA, sectionB) {
 							if (sectionA.sequenceNumber < sectionB.sequenceNumber) { return -1; }
 							if (sectionA.sequenceNumber > sectionB.sequenceNumber) { return 1; }


### PR DESCRIPTION
Unable to reproduce.

The method getSectionsBySectionGroupId is triggered in the courses view the first time you select a specific planned seats cell, or create a new sectionGroup, the sections are then used to render the sidebar.
The backend is properly written to complain if the sectionGroupId wasn't valid.

I made the state layer more defensive, will need to wait and see if it happens again.