### PR TITLE
CoursesView: Activities should use their tag color when displayed

### DIFF
--- a/app/scheduling/css/scheduling.css
+++ b/app/scheduling/css/scheduling.css
@@ -457,3 +457,7 @@ i.selected-section-group-remove {
 .section-in-series {
 	display: flex;
 }
+
+.filter-course--tag {
+	color: white;
+}

--- a/app/scheduling/directives/termCalendar.js
+++ b/app/scheduling/directives/termCalendar.js
@@ -48,6 +48,9 @@ schedulingApp.directive("termCalendar", this.termCalendar = function ($rootScope
 			var unavailabilityEventBorderColor = "#C6D2D6";
 			var unavailabilityEventTextColor = "#555555";
 
+			var tagEventTextColor = "#FFFFFF";
+			var selectedActivityTaggedColorShift = -80;
+
 			var refreshCalendar = function () {
 				var parentAspectRatio = element.parent().width() / element.parent().height();
 				element.fullCalendar('destroy');
@@ -104,9 +107,9 @@ schedulingApp.directive("termCalendar", this.termCalendar = function ($rootScope
 				});
 			};
 
-			// supply a color and amount to shift it by
-			// example to lighten: lightenOrDarkenColor("#F06D06", 20);
-			// example to darken: lightenOrDarkenColor("#F06D06", -20);
+			// Supply a color and amount to shift the color (out of 255)
+			// Example to lighten: lightenOrDarkenColor("#F06D06", 20);
+			// Example to darken: lightenOrDarkenColor("#F06D06", -20);
 			var lightenOrDarkenColor = function(col, amt) {
 				var usePound = false;
 
@@ -152,7 +155,7 @@ schedulingApp.directive("termCalendar", this.termCalendar = function ($rootScope
 					var unstyledEvents = sectionGroupToActivityEvents(sectionGroup);
 					var tagColor = calculateTagColor(sectionGroup);
 
-					var textColor = tagColor ? "#FFFFFF" : activeEventTextColor;
+					var textColor = tagColor ? tagEventTextColor : activeEventTextColor;
 					var borderColor = tagColor ? tagColor : activeEventBorderColor;
 					var backgroundColor = tagColor ? tagColor : activeEventBackgroundColor;
 
@@ -188,6 +191,8 @@ schedulingApp.directive("termCalendar", this.termCalendar = function ($rootScope
 				return calendarActivities;
 			};
 
+			// If a tag exists, identifies the color of the first one found.
+			// Otherwise, returns null
 			var calculateTagColor = function (sectionGroup) {
 				var tagColor = null;
 				var course = scope.view.state.courses.list[sectionGroup.courseId];
@@ -323,13 +328,14 @@ schedulingApp.directive("termCalendar", this.termCalendar = function ($rootScope
 				return calendarActivities;
 			};
 
+			// Generate a styled calendar event (text/background/border colors)
+			// Considers the selectedActivity in the UI, and supplied tag colors
 			var styleCalendarEvents = function (calendarActivities, backgroundColor, borderColor, textColor, tagColor) {
 				calendarActivities.forEach(function (event) {
-					console.log(scope.view.state.uiState.selectedActivityId);
 					if (scope.view.state.uiState.selectedActivityId === event.activityId) {
 						if (tagColor) {
-							event.color = lightenOrDarkenColor(tagColor, -80);
-							event.borderColor = lightenOrDarkenColor(tagColor, -80);
+							event.color = lightenOrDarkenColor(tagColor, selectedActivityTaggedColorShift);
+							event.borderColor = lightenOrDarkenColor(tagColor, selectedActivityTaggedColorShift);
 							event.textColor = textColor;
 						} else {
 							event.color = highlightedEventBackgroundColor;

--- a/app/scheduling/directives/termCalendar.js
+++ b/app/scheduling/directives/termCalendar.js
@@ -171,8 +171,6 @@ schedulingApp.directive("termCalendar", this.termCalendar = function ($rootScope
 							var sectionGroup = scope.view.state.sectionGroups.list[sgId];
 							var course = scope.view.state.courses.list[sectionGroup.courseId];
 							var unstyledEvents = sectionGroupToActivityEvents(scope.view.state.sectionGroups.list[sgId]);
-
-
 							var tagColor = scope.view.state.courses.list[sectionGroup.courseId].tagColor;
 
 							if (tagColor) {
@@ -192,7 +190,6 @@ schedulingApp.directive("termCalendar", this.termCalendar = function ($rootScope
 			};
 
 			var activityToEvents = function (activity, courseTitle) {
-
 				var calendarActivities = [];
 
 				if (activity.startTime && activity.endTime && activity.dayIndicator) {
@@ -374,7 +371,6 @@ schedulingApp.directive("termCalendar", this.termCalendar = function ($rootScope
 			$.extend(neonCalendar, {
 				isPresent: neonCalendar.$container.length > 0
 			});
-
 		}
 	};
 });

--- a/app/scheduling/directives/termCalendar.js
+++ b/app/scheduling/directives/termCalendar.js
@@ -121,10 +121,29 @@ schedulingApp.directive("termCalendar", this.termCalendar = function ($rootScope
 				if (scope.view.state.uiState.checkedSectionGroupIds.length > 0) {
 					scope.view.state.uiState.checkedSectionGroupIds.forEach(function (sgId) {
 						if (sgId !== scope.view.state.uiState.selectedSectionGroupId) {
+							var sectionGroup = scope.view.state.sectionGroups.list[sgId];
+							var course = scope.view.state.courses.list[sectionGroup.courseId];
 							var unstyledEvents = sectionGroupToActivityEvents(scope.view.state.sectionGroups.list[sgId]);
-							calendarActivities = calendarActivities.concat(
-								styleCalendarEvents(unstyledEvents)
-							);
+
+							// Determine tag color
+							var tagColor = null;
+
+							if (course.tagIds.length > 0) {
+								var tag = scope.view.state.tags.list[course.tagIds[0]];
+								if (tag.color) {
+									tagColor = tag.color;
+								}
+							}
+
+							if (tagColor) {
+								calendarActivities = calendarActivities.concat(
+									styleCalendarEvents(unstyledEvents, tagColor, tagColor, "white")
+								);
+							} else {
+								calendarActivities = calendarActivities.concat(
+									styleCalendarEvents(unstyledEvents)
+								);
+							}
 						}
 					});
 				}

--- a/app/scheduling/directives/termCalendar.js
+++ b/app/scheduling/directives/termCalendar.js
@@ -153,7 +153,7 @@ schedulingApp.directive("termCalendar", this.termCalendar = function ($rootScope
 				if (scope.view.state.uiState.selectedSectionGroupId) {
 					var sectionGroup = scope.view.state.sectionGroups.list[scope.view.state.uiState.selectedSectionGroupId];
 					var unstyledEvents = sectionGroupToActivityEvents(sectionGroup);
-					var tagColor = calculateTagColor(sectionGroup);
+					var tagColor = scope.view.state.courses.list[sectionGroup.courseId].tagColor;
 
 					var textColor = tagColor ? tagEventTextColor : activeEventTextColor;
 					var borderColor = tagColor ? tagColor : activeEventBorderColor;
@@ -173,7 +173,7 @@ schedulingApp.directive("termCalendar", this.termCalendar = function ($rootScope
 							var unstyledEvents = sectionGroupToActivityEvents(scope.view.state.sectionGroups.list[sgId]);
 
 
-							var tagColor = calculateTagColor(sectionGroup);
+							var tagColor = scope.view.state.courses.list[sectionGroup.courseId].tagColor;
 
 							if (tagColor) {
 								calendarActivities = calendarActivities.concat(
@@ -189,22 +189,6 @@ schedulingApp.directive("termCalendar", this.termCalendar = function ($rootScope
 				}
 
 				return calendarActivities;
-			};
-
-			// If a tag exists, identifies the color of the first one found.
-			// Otherwise, returns null
-			var calculateTagColor = function (sectionGroup) {
-				var tagColor = null;
-				var course = scope.view.state.courses.list[sectionGroup.courseId];
-
-				if (course.tagIds.length > 0) {
-					var tag = scope.view.state.tags.list[course.tagIds[0]];
-					if (tag.color) {
-						tagColor = tag.color;
-					}
-				}
-
-				return tagColor;
 			};
 
 			var activityToEvents = function (activity, courseTitle) {

--- a/app/scheduling/services/schedulingStateService.js
+++ b/app/scheduling/services/schedulingStateService.js
@@ -16,16 +16,26 @@ schedulingApp.service('schedulingStateService', function ($rootScope, $log, Cour
 				case INIT_STATE:
 					courses = {
 						newCourse: null,
-						ids: []
+						ids: [],
+						list: {}
 					};
-					var coursesList = {};
-					var length = action.payload.courses ? action.payload.courses.length : 0;
-					for (var i = 0; i < length; i++) {
-						var courseData = action.payload.courses[i];
-						coursesList[courseData.id] = new Course(courseData);
-					}
-					courses.ids = _array_sortIdsByProperty(coursesList, ["subjectCode", "courseNumber", "sequencePattern"]);
-					courses.list = coursesList;
+					action.payload.courses.forEach(function(courseData) {
+						courses.list[courseData.id] = new Course(courseData);
+						if (courseData.tagIds.length > 0) {
+							for (var i = 0; i < action.payload.tags.length; i++) {
+								var slotTag = action.payload.tags[i];
+								if (courseData.tagIds[0] == slotTag.id) {
+									var tag = slotTag;
+									break;
+								}
+							}
+
+							if (tag) {
+								courses.list[courseData.id].tagColor = tag.color;
+							}
+						}
+					});
+					courses.ids = _array_sortIdsByProperty(courses.list, ["subjectCode", "courseNumber", "sequencePattern"]);
 					return courses;
 				case UPDATE_TAG_FILTERS:
 					// Set the course.matchesTagFilters flag to true if any tag matches the filters

--- a/app/scheduling/templates/SchedulingCtrl.html
+++ b/app/scheduling/templates/SchedulingCtrl.html
@@ -68,10 +68,15 @@
 							{{ view.state.instructors.list[instructorId].fullName }}
 							<i class="glyphicon glyphicon-remove selected-section-group-remove clickable hoverable" ng-click="toggleInstructorFilter(instructorId)"></i>
 						</div>
-						<div class="label label-selected-section-group" ng-repeat="sectionGroupId in view.state.uiState.checkedSectionGroupIds track by $index">
-							{{ view.state.courses.list[view.state.sectionGroups.list[sectionGroupId].courseId].subjectCode }}
-							{{ view.state.courses.list[view.state.sectionGroups.list[sectionGroupId].courseId].courseNumber }} -
-							{{ view.state.courses.list[view.state.sectionGroups.list[sectionGroupId].courseId].sequencePattern }}
+						<div
+						class="label label-selected-section-group"
+						ng-init="course=view.state.courses.list[view.state.sectionGroups.list[sectionGroupId].courseId]"
+						ng-repeat="sectionGroupId in view.state.uiState.checkedSectionGroupIds track by $index"
+						ng-style="{'background-color': view.state.courses.list[view.state.sectionGroups.list[sectionGroupId].courseId].tagColor}"
+						ng-class="{'filter-course--tag': view.state.courses.list[view.state.sectionGroups.list[sectionGroupId].courseId].tagColor }">
+							{{ course.subjectCode }}
+							{{ course.courseNumber }} -
+							{{ course.sequencePattern }}
 							<i class="glyphicon glyphicon-remove selected-section-group-remove clickable hoverable" ng-click="toggleCheckedSectionGroup(sectionGroupId, $event)"></i>
 						</div>
 					</div>


### PR DESCRIPTION
Currently IPA does the following for the 3 kinds of visibility/course selection
<img width="774" alt="screen shot 2017-11-08 at 3 04 25 pm" src="https://user-images.githubusercontent.com/1776859/32579698-f5048276-c496-11e7-8a05-d04ea7708291.png">
<img width="762" alt="screen shot 2017-11-08 at 3 04 31 pm" src="https://user-images.githubusercontent.com/1776859/32579701-f6a908ae-c496-11e7-8238-6bd83405f6b5.png">
<img width="746" alt="screen shot 2017-11-08 at 3 04 35 pm" src="https://user-images.githubusercontent.com/1776859/32579704-f9017794-c496-11e7-83d8-97f06e8498cc.png">


The current change looks like this:
<img width="1149" alt="screen shot 2017-11-08 at 3 10 03 pm" src="https://user-images.githubusercontent.com/1776859/32579733-150438c8-c497-11e7-8724-acb9b3ee50fb.png">
<img width="1191" alt="screen shot 2017-11-08 at 3 10 08 pm" src="https://user-images.githubusercontent.com/1776859/32579737-17c1b856-c497-11e7-8658-fd872b4781de.png">
<img width="1166" alt="screen shot 2017-11-08 at 3 10 13 pm" src="https://user-images.githubusercontent.com/1776859/32579741-1a212b7c-c497-11e7-8523-e2fa63210631.png">

IPA's current behavior is a little strange, with no visual change after selecting a sectionGroup (picture 2).

I think selecting a sectionGroup should do something, but unclear what. going from red -> gray -> teal may not be best.