### PR TITLE
SupportAssignments: Reader preferences were not being reflected in the support assignment 'by course' pivot

### DIFF
--- a/app/instructionalSupport/assignment/services/supportAssignmentSelectors.js
+++ b/app/instructionalSupport/assignment/services/supportAssignmentSelectors.js
@@ -188,7 +188,7 @@ instructionalSupportApp.service('supportAssignmentSelectors', function () {
 					var preference = supportStaffPreferences.list[preferenceId];
 
 					if (preference.sectionGroupId != sectionGroup.id
-							|| preference.type != "associateInstructor") {
+							|| preference.type != "reader") {
 						return;
 					}
 


### PR DESCRIPTION
Bug Report:
When in the support assignment page,
I clicked on an existing reader slot to assign a support staff,
I expected to see readers who had indicated a preference (on their support call form)  to be a reader for this course listed at the top,
Instead no reader preferences were ever displayed.

Issue:
https://github.com/ucdavis/ipa-client-angular/issues/1454