### PR TITLE
Remove Konami easter egg

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -139,8 +139,7 @@ module.exports = function (grunt) {
 			jsProdSnippets: {
 				src: [
 					'vendor/js/userEcho.js',
-					'vendor/js/googleAnalytics.js',
-					'vendor/js/konami.js'
+					'vendor/js/googleAnalytics.js'
 				],
 				dest: '<%= folders.webapp.build %>/js/snippets.js'
 			},

--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,6 @@
     "angular-ui-select": "0.19.1",
     "angular-sanitize": "1.5.8",
     "bootstrap": "3.3.6",
-    "konami-js": "1.4.6",
     "mjolnic-bootstrap-colorpicker": "bootstrap-colorpicker#^2.3.3",
     "ng-idle": "1.3.1",
     "underscore": "1.8.3",

--- a/vendor/js/konami.js
+++ b/vendor/js/konami.js
@@ -1,6 +1,0 @@
-var easter_egg = new Konami(function () {
-	var KICKASSVERSION = '2.0';
-	var s = document.createElement('script');
-	s.type = 'text/javascript'; document.body.appendChild(s);
-	s.src = '//hi.kickassapp.com/kickass.js';
-});


### PR DESCRIPTION
Remove the Konami easter egg. It seems to have been broken, plus we don't need the extra network resources and size.