### PR TITLE
DRY up term code-related lookups. Remove related dead code.

### DIFF
--- a/app/assignment/controllers/AssignmentCtrl.js
+++ b/app/assignment/controllers/AssignmentCtrl.js
@@ -188,7 +188,6 @@ assignmentApp.controller('AssignmentCtrl', ['$scope', '$rootScope', '$window', '
 
 				var termDisplayNames = {};
 
-
 				modalInstance = $uibModal.open({
 					templateUrl: 'ModalUnavailability.html',
 					controller: ModalUnavailabilityCtrl,

--- a/app/instructionalSupport/assignment/controllers/InstructionalSupportAssignmentCtrl.js
+++ b/app/instructionalSupport/assignment/controllers/InstructionalSupportAssignmentCtrl.js
@@ -130,7 +130,6 @@ instructionalSupportApp.controller('InstructionalSupportAssignmentCtrl', ['$scop
 			};
 
 			$scope.openAddAppointmentSlotModal = function(sectionGroupId, appointmentType) {
-
 				modalInstance = $uibModal.open({
 					templateUrl: 'AddAssignmentSlotModal.html',
 					controller: ModalAddAssignmentSlotCtrl,
@@ -189,39 +188,6 @@ instructionalSupportApp.controller('InstructionalSupportAssignmentCtrl', ['$scop
 				instructionalSupportAssignmentActionCreators.removeStaffFromSlot(supportAssignment.id, supportStaffId);
 			};
 
-			$scope.getTermDescription = function(term) {
-				var endingYear = "";
-				if (term && term.length == 6) {
-					endingYear = term.substring(0,4);
-					term = term.slice(-2);
-				}
-
-				termNames = {
-					'05': 'Summer Session 1',
-					'06': 'Summer Special Session',
-					'07': 'Summer Session 2',
-					'08': 'Summer Quarter',
-					'09': 'Fall Semester',
-					'10': 'Fall Quarter',
-					'01': 'Winter Quarter',
-					'02': 'Spring Semester',
-					'03': 'Spring Quarter'
-				};
-
-				return termNames[term];
-			};
-
-			$scope.getTermYearDescription = function(term, year) {
-
-				var description = "";
-				if (parseInt(term) < 4) {
-					year = parseInt(year) + 1;
-				}
-
-				description = $scope.getTermDescription(term) + " " + year;
-				return description;
-			};
-
 			$scope.toggleSupportStaffSupportCallReview = function() {
 				instructionalSupportAssignmentActionCreators.toggleSupportStaffSupportCallReview($scope.view.state.schedule.id, $scope.termShortCode);
 			};
@@ -229,8 +195,6 @@ instructionalSupportApp.controller('InstructionalSupportAssignmentCtrl', ['$scop
 			$scope.toggleInstructorSupportCallReview = function() {
 				instructionalSupportAssignmentActionCreators.toggleInstructorSupportCallReview($scope.view.state.schedule.id, $scope.termShortCode);
 			};
-
-			$scope.termYearDescription = $scope.getTermYearDescription($scope.termShortCode, $scope.year);
 
 			// Set the active tab according to the URL
 			// Otherwise redirect to the default view

--- a/app/registrarReconciliationReport/controllers/ReportCtrl.js
+++ b/app/registrarReconciliationReport/controllers/ReportCtrl.js
@@ -60,28 +60,6 @@ registrarReconciliationReportApp.controller('ReportCtrl', ['$scope', '$rootScope
 			$scope.fullTerms.push(fullTerm);
 		}
 
-		$scope.getTermName = function(term) {
-			var endingYear = "";
-			if (term && term.length == 6) {
-				endingYear = term.substring(0,4);
-				term = term.slice(-2);
-			}
-
-			termNames = {
-				'05': 'Summer Session 1',
-				'06': 'Summer Special Session',
-				'07': 'Summer Session 2',
-				'08': 'Summer Quarter',
-				'09': 'Fall Semester',
-				'10': 'Fall Quarter',
-				'01': 'Winter Quarter',
-				'02': 'Spring Semester',
-				'03': 'Spring Quarter'
-			};
-
-			return termNames[term] + " " + endingYear;
-		};
-
 	}
 ]);
 

--- a/app/scheduleSummaryReport/controllers/ScheduleSummaryReportCtrl.js
+++ b/app/scheduleSummaryReport/controllers/ScheduleSummaryReportCtrl.js
@@ -68,28 +68,6 @@ scheduleSummaryReportApp.controller('ScheduleSummaryReportCtrl', ['$scope', '$ro
 			$scope.fullTerms.push(fullTerm);
 		}
 
-		$scope.getTermName = function(term) {
-			var endingYear = "";
-			if (term && term.length == 6) {
-				endingYear = term.substring(0,4);
-				term = term.slice(-2);
-			}
-
-			termNames = {
-				'05': 'Summer Session 1',
-				'06': 'Summer Special Session',
-				'07': 'Summer Session 2',
-				'08': 'Summer Quarter',
-				'09': 'Fall Semester',
-				'10': 'Fall Quarter',
-				'01': 'Winter Quarter',
-				'02': 'Spring Semester',
-				'03': 'Spring Quarter'
-			};
-
-			return termNames[term] + " " + endingYear;
-		};
-
 	}
 ]);
 

--- a/app/shared/services/termService.js
+++ b/app/shared/services/termService.js
@@ -1,0 +1,41 @@
+/**
+ * @ngdoc service
+ * @name ipaClientAngularApp.termService
+ * @description
+ * # termService
+ * Service in the ipaClientAngularApp.
+ */
+angular.module('sharedApp')
+	.service('termService', function () {
+		return {
+			termCodeDescriptions: {
+				'05': 'Summer Session 1',
+				'06': 'Summer Special Session',
+				'07': 'Summer Session 2',
+				'08': 'Summer Quarter',
+				'09': 'Fall Semester',
+				'10': 'Fall Quarter',
+				'01': 'Winter Quarter',
+				'02': 'Spring Semester',
+				'03': 'Spring Quarter'
+			},
+
+			/**
+			 * Returns full term description given termCode, e.g. 201710 -> "Fall Quarter 2017"
+			 * @param {string} termCode
+			 * @returns {string} Full term description with year, e.g. "Fall Quarter 2017"
+			 */
+			getTermName: function(termCode) {
+				var year, shortTermCode;
+
+				if (!termCode || termCode.length != 6) {
+					return null;
+				}
+
+				year = termCode.substring(0, 4);
+				shortTermCode = termCode.slice(-2);
+	
+				return this.termCodeDescriptions[shortTermCode] + " " + year;
+			}
+		};
+	});

--- a/app/teachingCall/teachingCallStatus/controllers/ModalAddInstructorsCtrl.js
+++ b/app/teachingCall/teachingCallStatus/controllers/ModalAddInstructorsCtrl.js
@@ -1,4 +1,13 @@
-teachingCallApp.controller('ModalAddInstructorsCtrl', this.ModalAddInstructorsCtrl = function($scope, $rootScope, $uibModalInstance, scheduleYear, workgroupId, state) {
+/**
+ * @ngdoc function
+ * @name ipaClientAngularApp.controller:ModalAddInstructorsCtrl
+ * @description
+ * # ModalAddInstructorsCtrl
+ * Controller of the ipaClientAngularApp
+ */
+teachingCallApp.controller('ModalAddInstructorsCtrl', ['$scope', '$rootScope', '$uibModalInstance', 'scheduleYear', 'workgroupId', 'state', 'termService',
+	this.ModalAddInstructorsCtrl = function($scope, $rootScope, $uibModalInstance, scheduleYear, workgroupId, state, termService) {
+	
 	$scope.startTeachingCallConfig = {};
 	$scope.startTeachingCallConfig.dueDate = "";
 	$scope.startTeachingCallConfig.showUnavailabilities = true;
@@ -136,21 +145,6 @@ teachingCallApp.controller('ModalAddInstructorsCtrl', this.ModalAddInstructorsCt
 		$scope.startTeachingCallConfig.isAddInstructorFormComplete = $scope.isAddInstructorFormComplete();
 	};
 
-	$scope.activeTermsDescription = function () {
-		var description = "";
-
-		for (var i = 0; i < $scope.allTerms.length; i++) {
-			if ($scope.startTeachingCallConfig.activeTerms && $scope.startTeachingCallConfig.activeTerms[$scope.allTerms[i]]) {
-				if (description.length > 0) {
-					description += ", ";
-				}
-				description += $scope.getTermName($scope.allTerms[i]);
-			}
-		}
-
-		return description;
-	};
-
 	$scope.addSenateInstructors = function () {
 		$scope.startTeachingCallConfig.invitedInstructors.forEach(function(slotInstructor) {
 			if(slotInstructor.isSenateInstructor) {
@@ -237,25 +231,7 @@ teachingCallApp.controller('ModalAddInstructorsCtrl', this.ModalAddInstructorsCt
 	};
 
 	$scope.getTermName = function(term) {
-		var endingYear = "";
-		if (term.length == 6) {
-			endingYear = term.substring(0,4);
-			term = term.slice(-2);
-		}
-
-		termNames = {
-			'05': 'Summer Session 1',
-			'06': 'Summer Special Session',
-			'07': 'Summer Session 2',
-			'08': 'Summer Quarter',
-			'09': 'Fall Semester',
-			'10': 'Fall Quarter',
-			'01': 'Winter Quarter',
-			'02': 'Spring Semester',
-			'03': 'Spring Quarter'
-		};
-
-		return termNames[term] + " " + endingYear;
+		return termService.getTermName(term);
 	};
 
 	// Datepicker config
@@ -290,56 +266,5 @@ teachingCallApp.controller('ModalAddInstructorsCtrl', this.ModalAddInstructorsCt
 		$uibModalInstance.close($scope.startTeachingCallConfig);
 	};
 
-	$scope.termDescriptions = function () {
-		$scope.startTeachingCallConfig.activeTerms;
-		// Convert termsBlob to terms
-		var allTerms = ['01', '02', '03', '04', '05', '06', '07', '08', '09','10'];
-		var relevantTerms = [];
-
-		allTerms.forEach( function(term) {
-			$scope.startTeachingCallConfig;
-			if ($scope.startTeachingCallConfig.activeTerms && $scope.startTeachingCallConfig.activeTerms[term]) {
-				relevantTerms.push(term);
-			}
-		});
-
-		// sort terms Chronologically
-		var chronologicallyOrderedTerms = ['05', '06', '07', '08', '09', '10', '01', '02', '03'];
-		var sortedTerms = [];
-		chronologicallyOrderedTerms.forEach( function(term) {
-			if (relevantTerms.indexOf(term) > -1) {
-				sortedTerms.push(term);
-			}
-		});
-		// Convert termCodes to term descriptions
-		allTermDescriptions = {
-			'05': 'Summer Session 1',
-			'06': 'Summer Special Session',
-			'07': 'Summer Session 2',
-			'08': 'Summer Quarter',
-			'09': 'Fall Semester',
-			'10': 'Fall Quarter',
-			'01': 'Winter Quarter',
-			'02': 'Spring Semester',
-			'03': 'Spring Quarter'
-		};
-
-		// Comma Separated term descriptions
-		termDescriptions = "";
-		firstTerm = true;
-		sortedTerms.forEach(function(term) {
-
-			if (firstTerm) {
-				termDescriptions += allTermDescriptions[term];
-				firstTerm = false;
-			} else {
-				termDescriptions += ", ";
-				termDescriptions += allTermDescriptions[term];
-			}
-		});
-
-		return termDescriptions;
-	};
-
 	$scope.startTeachingCallConfig.isAddInstructorFormComplete = $scope.isAddInstructorFormComplete();
-});
+}]);

--- a/app/teachingCall/teachingCallStatus/controllers/ModalContactInstructorsCtrl.js
+++ b/app/teachingCall/teachingCallStatus/controllers/ModalContactInstructorsCtrl.js
@@ -109,49 +109,12 @@ teachingCallApp.controller('ModalContactInstructorsCtrl', this.ModalContactInstr
 		$scope.startTeachingCallConfig.activeTerms[term] = !$scope.startTeachingCallConfig.activeTerms[term];
 	};
 
-	$scope.activeTermsDescription = function () {
-		var description = "";
-
-		for (var i = 0; i < $scope.allTerms.length; i++) {
-			if ($scope.startTeachingCallConfig.activeTerms && $scope.startTeachingCallConfig.activeTerms[$scope.allTerms[i]]) {
-				if (description.length > 0) {
-					description += ", ";
-				}
-				description += $scope.getTermName($scope.allTerms[i]);
-			}
-		}
-
-		return description;
-	};
-
 	$scope.toggleSenateInstructors = function () {
 		$scope.startTeachingCallConfig.sentToSenate = !$scope.startTeachingCallConfig.sentToSenate;
 	};
 
 	$scope.toggleFederationInstructors = function () {
 		$scope.startTeachingCallConfig.sentToFederation = !$scope.startTeachingCallConfig.sentToFederation;
-	};
-
-	$scope.getTermName = function(term) {
-		var endingYear = "";
-		if (term.length == 6) {
-			endingYear = term.substring(0,4);
-			term = term.slice(-2);
-		}
-
-		termNames = {
-			'05': 'Summer Session 1',
-			'06': 'Summer Special Session',
-			'07': 'Summer Session 2',
-			'08': 'Summer Quarter',
-			'09': 'Fall Semester',
-			'10': 'Fall Quarter',
-			'01': 'Winter Quarter',
-			'02': 'Spring Semester',
-			'03': 'Spring Quarter'
-		};
-
-		return termNames[term] + " " + endingYear;
 	};
 
 	// Datepicker config

--- a/app/teachingCall/teachingCallStatus/controllers/ModalTeachingCallConfigCtrl.js
+++ b/app/teachingCall/teachingCallStatus/controllers/ModalTeachingCallConfigCtrl.js
@@ -103,53 +103,12 @@ teachingCallApp.controller('ModalTeachingCallConfigCtrl', this.ModalTeachingCall
 		$scope.startTeachingCallConfig.activeTerms[term] = !$scope.startTeachingCallConfig.activeTerms[term];
 	};
 
-	$scope.getTermName = function (term) {
-		return termService.getTermName(term);
-	};
-
-	$scope.activeTermsDescription = function () {
-		var description = "";
-
-		for (var i = 0; i < $scope.allTerms.length; i++) {
-			if ($scope.startTeachingCallConfig.activeTerms && $scope.startTeachingCallConfig.activeTerms[$scope.allTerms[i]]) {
-				if (description.length > 0) {
-					description += ", ";
-				}
-				description += $scope.getTermName($scope.allTerms[i]);
-			}
-		}
-
-		return description;
-	};
-
 	$scope.toggleSenateInstructors = function () {
 		$scope.startTeachingCallConfig.sentToSenate = !$scope.startTeachingCallConfig.sentToSenate;
 	};
 
 	$scope.toggleFederationInstructors = function () {
 		$scope.startTeachingCallConfig.sentToFederation = !$scope.startTeachingCallConfig.sentToFederation;
-	};
-
-	$scope.getTermName = function(term) {
-		var endingYear = "";
-		if (term.length == 6) {
-			endingYear = term.substring(0,4);
-			term = term.slice(-2);
-		}
-
-		termNames = {
-			'05': 'Summer Session 1',
-			'06': 'Summer Special Session',
-			'07': 'Summer Session 2',
-			'08': 'Summer Quarter',
-			'09': 'Fall Semester',
-			'10': 'Fall Quarter',
-			'01': 'Winter Quarter',
-			'02': 'Spring Semester',
-			'03': 'Spring Quarter'
-		};
-
-		return termNames[term] + " " + endingYear;
 	};
 
 	// Datepicker config


### PR DESCRIPTION
IPA has a confused relationship with the concept of terms. Search for 'Fall Quarter' to see what I mean.

There is a lot of duplicated code and dead code relating to terms. On top of that, we extend the String prototype with term-related functions, have a Term entity class, and I've just introduced a shared TermService.

This PR doesn't fix these problems but it moves the needle in the right direction.