### PR TITLE
SupportAssignments: Fix preference comment styling

### DIFF
--- a/app/instructionalSupport/assignment/instructionalSupportAssignment.css
+++ b/app/instructionalSupport/assignment/instructionalSupportAssignment.css
@@ -645,6 +645,7 @@ margin-left: 6px;
 
 .support-staff-assignment-sub-detail {
 	font-weight: normal;
+	width: 100%;
 }
 
 .course-assignment-selector {


### PR DESCRIPTION
During a supportAssignment review if an instructor looks at the by support staff pivot, preferences that have lengthy comments will be displayed incorrectly and bleed outside the box.

Related issue
https://github.com/ucdavis/ipa-client-angular/issues/1474