### PR TITLE
ReconciliationReport: Instructor dropdown renders incorrectly

### DIFF
--- a/app/registrarReconciliationReport/directives/instructorDiff/instructorDiff.html
+++ b/app/registrarReconciliationReport/directives/instructorDiff/instructorDiff.html
@@ -2,17 +2,17 @@
 	'has-changes' : (instructor.noRemote || instructor.noLocal) && !instructor.isToDo,
 	'no-remote' : instructor.noRemote && !instructor.isToDo,
 	'no-local': instructor.noLocal && !instructor.isToDo }" class="section-diff-element section-instructors"
-	ng-click="setActiveChangeAction($event, instructor, $index)">
+	ng-click="setActiveChangeAction($event, instructor, uniqueIndex)">
 	<span class="diff-content">
 		{{ instructor | lastSpaceInitial }}
 	</span>
 
-	<change-action ng-if="instructor.noRemote" ng-show="view.activeChangeAction == instructor.uniqueKey + $index"
+	<change-action ng-if="instructor.noRemote" ng-show="view.activeChangeAction == instructor.uniqueKey + uniqueIndex"
 		title="Banner does not have this instructor" sis-value-message="Un-assign in IPA (All sections)" ipa-value-message="Mark to assign in Banner"
 		apply-sis="unAssignInstructor(section, instructor)" apply-ipa="toggleBannerToDoItem('instructors', instructor.uniqueKey)"
 		is-active="view.hasAccess"></change-action>
 
-	<change-action ng-if="instructor.noLocal" ng-show="view.activeChangeAction == instructor.uniqueKey + $index"
+	<change-action ng-if="instructor.noLocal" ng-show="view.activeChangeAction == instructor.uniqueKey + uniqueIndex"
 		title="IPA does not have this instructor" sis-value-message="Assign in IPA (All sections)" ipa-value-message="Mark to un-assign in Banner"
 		apply-sis="assignInstructor(section, instructor)" apply-ipa="toggleBannerToDoItem('instructors', instructor.uniqueKey)"
 		is-active="view.hasAccess"></change-action>

--- a/app/registrarReconciliationReport/directives/instructorDiff/instructorDiff.js
+++ b/app/registrarReconciliationReport/directives/instructorDiff/instructorDiff.js
@@ -8,6 +8,7 @@ registrarReconciliationReportApp.directive("instructorDiff", this.instructorDiff
 		templateUrl: 'instructorDiff.html',
 		replace: true,
 		link: function (scope, element, attrs) {
+			scope.uniqueIndex = attrs.uniqueIndex;
 			scope.assignInstructor = function () {
 				reportActionCreators.assignInstructor(scope.section, scope.instructor);
 			};

--- a/app/registrarReconciliationReport/templates/sectionDiff.html
+++ b/app/registrarReconciliationReport/templates/sectionDiff.html
@@ -11,8 +11,11 @@
 		</div>
 
 		<!-- Instructors -->
-		<div class="section-group-instructors" ng-if="section.groupHead">
-			<instructor-diff ng-repeat="instructor in section.instructors track by $index"></instructor-diff>
+		<div class="section-group-instructors" ng-show="section.groupHead">
+			<instructor-diff
+			ng-repeat="instructor in section.instructors track by $index"
+			unique-index="{{ section.subjectCode + '-'+ section.courseNumber + '-' + section.sequenceNumber + '-' + instructor.uniqueKey }}">
+			</instructor-diff>
 		</div>
 
 		<!-- Action when section does not exist in Banner -->


### PR DESCRIPTION
This PR resolves the issue where instructor drop downs would render repeatedly.

Was caused by the addition of ng-if's to the view over time, which create new scopes, and cause $index to always return 0 when its no longer inside a ng-repeat scope. In this case, $index was an inappropriate identifier anyways, so I replaced it with a truly unique one.

Additionally, there was a second bug where opening a tooltip from an instructor was always triggering other instances of the same instructor from different courses, this is resolved as well by making the identifier unique.

Issue:
https://trello.com/c/OC59KM1R/313-registrar-reconciliation-report-instructor-dropdown-renders-incorrectly
  