### PR TITLE
bugfix/term selector

### DIFF
--- a/app/shared/directives/ipaTermSelectorDropdown/ipaTermSelectorDropdown.js
+++ b/app/shared/directives/ipaTermSelectorDropdown/ipaTermSelectorDropdown.js
@@ -24,16 +24,7 @@ sharedApp.directive('ipaTermSelectorDropdown', function($window, $location, $rou
 			scope.termDefinitions = Term.prototype.generateTable(scope.year);
 
 			scope.getScheduleTerms = function () {
-				if (!scope.termStates) { return; }
-
-				var activeTerms = scope.termStates.map(function (termState) {
-					return termState.termCode;
-				});
-				var scheduleTerms = scope.termDefinitions.filter(function (term) {
-					return activeTerms.indexOf(term.code) >= 0;
-				});
-
-				return scheduleTerms;
+				return scope.termDefinitions;
 			};
 
 			scope.scheduleTerms = scope.getScheduleTerms();
@@ -44,7 +35,7 @@ sharedApp.directive('ipaTermSelectorDropdown', function($window, $location, $rou
 				}
 			});
 
-			if (scope.currentTermDescription == null) {
+			if (scope.termShortCode == null) {
 				scope.readOnlyMode = true;
 				scope.currentTermDescription = "Annual";
 			}


### PR DESCRIPTION
Original report stated there was an issue when demoing to school of law where relevant terms weren't showing in term selector dropdown, and irrelevant terms were showing up.

Solution:
After investigating, termState calculations come from the backend and are calculated based on the userRoles of the logged in user.

I was only able to reproduce this by navigating directly to the scheduling view as an admin:
http://localhost:9000/scheduling/31/2017/10

In this case, it would display SS1/SS2/fall quarter/winter quarter/spring quarters (which are the appropriate terms for DSS IT).

If I put myself in the workgroup and reload the page, the term selector displays a mixture of DSS IT terms and school of law terms.

Short term, I'll make the dropdown offer all terms always, which we had been contemplating might be a better user experience anyways.

Long term, to do the bolding of terms reliably, we should probably move termState gathering to a separate route, so the front end can ask specifically by workgroupId, rather than having to rely on userRoles.

issue:
https://trello.com/c/vXCNOMgo/390-2-termselector-does-not-show-expected-terms