### PR TITLE
Bugfix/student preference null

### DIFF
--- a/app/instructionalSupport/studentSupportCallForm/services/studentReducers.js
+++ b/app/instructionalSupport/studentSupportCallForm/services/studentReducers.js
@@ -110,6 +110,37 @@ instructionalSupportApp.service('studentReducers', function ($rootScope, $log, s
 			}
 		},
 		_uiReducers: function (action, ui) {
+			// Return default ui object if studentSupportCallResponse is not present
+			// In this case the page will display a warning that you were not invited to a support call
+			if (action.payload.studentSupportCallResponse == null || action.payload.studentSupportCallResponse == false) {
+				return {
+					isPreferenceCommentModalOpen: false,
+					isFormLocked: false,
+					crnSearch: {
+						crn: null,
+						feedback: null,
+						blob: null,
+						displayTimes: null
+					},
+					review: {
+						isFormValid: true,
+						validationErrorMessage: null,
+						requirePreferenceAmount: {
+							required: false,
+							complete: false
+						},
+						requireEligible: {
+							required: false,
+							complete: false
+						},
+						requirePreferenceComments: {
+							required: false,
+							complete: false
+						}
+					}
+				};
+			}
+
 			switch (action.type) {
 				case INIT_STATE:
 					var preferenceCommentsComplete = true;
@@ -146,16 +177,15 @@ instructionalSupportApp.service('studentReducers', function ($rootScope, $log, s
 
 
 					// Determine if form should be locked (due date is enforced and has passed)
-					if (action.payload.supportCallResponse) {
-						var dueDate = action.payload.supportCallResponse.dueDate;
-						var dueDateEnforced = action.payload.supportCallResponse.allowSubmissionAfterDueDate == false;
-						if (dueDate && dueDateEnforced) {
-							var currentTime = new Date().getTime();
-							if (currentTime > dueDate) {
-								ui.isFormLocked = true;
-							}
+					var dueDate = action.payload.studentSupportCallResponse.dueDate;
+					var dueDateEnforced = action.payload.studentSupportCallResponse.allowSubmissionAfterDueDate == false;
+					if (dueDate && dueDateEnforced) {
+						var currentTime = new Date().getTime();
+						if (currentTime > dueDate) {
+							ui.isFormLocked = true;
 						}
 					}
+
 					return ui;
 				case CLEAR_CRN_SEARCH:
 					ui.crnSearch.crn = null;

--- a/app/summary/directives/instructorSummary/instructorHeader/instructorHeader.js
+++ b/app/summary/directives/instructorSummary/instructorHeader/instructorHeader.js
@@ -28,6 +28,10 @@ summaryApp.directive("instructorHeader", this.instructorHeader = function ($rout
 			scope.openReviewBlobToTerms = function(openReviewBlob) {
 				var terms = [];
 
+				if (openReviewBlob == false || openReviewBlob == null) {
+					return terms;
+				}
+
 				for (var i = 0; i < openReviewBlob.length; i++) {
 					if (openReviewBlob[i] == "1") {
 						var term = String(i + 1);


### PR DESCRIPTION
Was caused by loading a support call url when not invited to the support call. Frontend does display a splash message to the user, but state calculations assumed it would be set and hit an error.

Issue:
https://trello.com/c/3HZR63Wq/1505-studentsupportcallform-cannot-read-property-minimumnumberofpreferences-of-null