### PR TITLE
StudentSupportCallForm: Make availability collection more flexible

### DIFF
--- a/app/instructionalSupport/studentSupportCallForm/directives/studentAvailabilities/crnAvailable/crnAvailable.html
+++ b/app/instructionalSupport/studentSupportCallForm/directives/studentAvailabilities/crnAvailable/crnAvailable.html
@@ -51,7 +51,8 @@
 	</div>
 	<div class="crn-available__grid-container">
 		<grid-available
-			read-only="true"
+			ng-if="state.supportCallResponse"
+			read-only="state.supportCallResponse.collectAvailabilityByGrid == false"
 			support-call-response="state.supportCallResponse">
 		</grid-available>
 	</div>

--- a/app/supportCall/directives/modalAddSupportCall/AddSupportCallModal.html
+++ b/app/supportCall/directives/modalAddSupportCall/AddSupportCallModal.html
@@ -180,20 +180,13 @@
 									<div class="modal-add-support-call__checkbox">
 										<ipa-checkbox
 											is-checked="supportCallConfigData.collectAvailabilityByCrn"
-											click-action="toggleCollectAvailabilityByCrn()"
-											is-disabled="!(supportCallConfigData.collectAvailabilityByGrid)">
+											click-action="toggleCollectAvailabilityByCrn()">
 										</ipa-checkbox>
 									</div>
 									<div class="modal-add-support-call__checkbox-label"
-										ng-show="supportCallConfigData.collectAvailabilityByGrid"
 										ng-click="toggleCollectAvailabilityByCrn()">
 											Collect availability (via CRN)
 									</div>
-									<div class="modal-add-support-call__checkbox-label modal-add-support-call__checkbox-label--disabled"
-										ng-show="!(supportCallConfigData.collectAvailabilityByGrid)">
-											Collect availability (via CRN)
-									</div>
-
 								</li>
 
 								<li ng-if="supportCallConfigData.mode == 'supportStaff'" role="menuitem" ng-click="toggleCollectEligibilityConfirmation()">

--- a/app/supportCall/directives/modalAddSupportCall/modalAddSupportCall.css
+++ b/app/supportCall/directives/modalAddSupportCall/modalAddSupportCall.css
@@ -15,8 +15,3 @@
 .modal-add-support-call__checkbox-label {
 	cursor: pointer;
 }
-
-.modal-add-support-call__checkbox-label--disabled {
-	color: #ccc;
-	cursor: default;
-}


### PR DESCRIPTION
Form should support submission of availability via crn and painting at the same time.

Issue:
https://trello.com/c/KoaByrcy/1519-studentsupportcallform-should-support-crn-availability-and-painting-options-if-both-options-are-checked-in-config