### PR TITLE
BudgetView: Should render newlines in comment modals

### DIFF
--- a/app/budget/directives/modals/addCourseComments/addCourseComments.css
+++ b/app/budget/directives/modals/addCourseComments/addCourseComments.css
@@ -19,6 +19,7 @@
 
 .add-course-comments .comment-body {
 	padding: 1%;
+	white-space: pre-wrap;
 }
 
 .add-course-comments .comment-textarea {

--- a/app/budget/directives/modals/addLineItemComments/addLineItemComments.css
+++ b/app/budget/directives/modals/addLineItemComments/addLineItemComments.css
@@ -19,6 +19,7 @@
 
 .add-line-item-comments .comment-body {
 	padding: 1%;
+	white-space: pre-wrap;
 }
 
 .add-line-item-comments .comment-textarea {


### PR DESCRIPTION
Issue:
https://trello.com/c/FZ6300gt/1550-budgetview-comment-models-should-properly-render-newlines-white-space