### PR TITLE
Bugfix/scheduling-duplicate-repeater

### DIFF
--- a/app/scheduling/templates/SchedulingCtrl.html
+++ b/app/scheduling/templates/SchedulingCtrl.html
@@ -157,7 +157,7 @@
 								<div ng-if="view.state.sectionGroups.list[sectionGroupId].instructorIds.length">
 									instructor{{ view.state.sectionGroups.list[sectionGroupId].instructorIds.length > 1 ? 's':'' }}:
 									<div class="label label-default" style="padding: 3px; margin-left: 3px;"
-										ng-repeat="instructorId in view.state.sectionGroups.list[sectionGroupId].instructorIds track by instructorId">
+										ng-repeat="instructorId in view.state.sectionGroups.list[sectionGroupId].instructorIds track by $index">
 										{{ view.state.instructors.list[instructorId] | lastSpaceInitial }}{{ $last ? '':', '}}
 									</div>
 								</div>


### PR DESCRIPTION
Should not use instructorId as unique identifier in ngRepeat. When a course had the same instructor assigned twice, this caused a front end error. We allow this before in the assignments page, though its not clear why a department would want to do this.

Issue:
https://trello.com/c/hu1e7Jye/1534-schedulingview-duplicates-in-a-repeater-are-not-allowed