### PR TITLE
Bugfix/firefox numeric input

### DIFF
--- a/app/budget/directives/courseCosts/courseCosts.js
+++ b/app/budget/directives/courseCosts/courseCosts.js
@@ -52,7 +52,7 @@ budgetApp.directive("courseCosts", this.courseCosts = function ($rootScope, budg
 					sectionGroup.overrideReaderAppointments = null;
 				}
 
-				budgetActions.overrideSectionGroup(sectionGroup, property);
+				budgetActions.overrideSectionGroup(sectionGroup, property, isReversion = true);
 			};
 
 			scope.toCurrency = function (value) {

--- a/app/budget/directives/courseCosts/courseCosts.js
+++ b/app/budget/directives/courseCosts/courseCosts.js
@@ -18,7 +18,26 @@ budgetApp.directive("courseCosts", this.courseCosts = function ($rootScope, budg
 			};
 
 			scope.overrideSectionGroup = function(sectionGroup, property) {
+				sectionGroup = scope.enforceNumericParams(sectionGroup);
 				budgetActions.overrideSectionGroup(sectionGroup, property);
+			};
+
+			// Will ensure certain properties are numbers, if they exist on the object.
+			scope.enforceNumericParams = function(obj) {
+				var propertiesShouldBeNumber = [
+					"overrideTeachingAssistantAppointments",
+					"overrideSectionCount",
+					"overrideReaderAppointments",
+					"overrideTotalSeats"
+				];
+
+				propertiesShouldBeNumber.forEach(function(property) {
+					if (obj[property] != null) {
+						obj[property] = parseFloat(obj[property]);
+					}
+				});
+
+				return obj;
 			};
 
 			// Reverts the specified override value

--- a/app/budget/services/actions/budgetActions.js
+++ b/app/budget/services/actions/budgetActions.js
@@ -49,7 +49,7 @@ budgetApp.service('budgetActions', function ($rootScope, $window, budgetService,
 		},
 		// Compares sectionGroup values, the updated override value, and the sectionGroupCost to determine what action to take.
 		// Will potentially create, delete, or update a sectionGroupCost
-		overrideSectionGroup: function (sectionGroup, property) {
+		overrideSectionGroup: function (sectionGroup, property, isReversion) {
 			var oldValue = null;
 			var newValue = null;
 			var savedOverride = null;
@@ -62,29 +62,28 @@ budgetApp.service('budgetActions', function ($rootScope, $window, budgetService,
 			if (property == "seats") {
 				savedOverride = sectionGroup.sectionGroupCost ? sectionGroup.sectionGroupCost.enrollment : null;
 				oldValue = savedOverride || sectionGroup.totalSeats;
-				newValue = sectionGroup.overrideTotalSeats;
-
+				newValue = this._calculateNewValue(sectionGroup.overrideTotalSeats, isReversion);
 				newSectionGroupCost.enrollment = sectionGroup.overrideTotalSeats;
 			}
 
 			else if (property == "sectionCount") {
 				savedOverride = sectionGroup.sectionGroupCost ? sectionGroup.sectionGroupCost.sectionCount : null;
 				oldValue = savedOverride || sectionGroup.sectionCount;
-				newValue = sectionGroup.overrideSectionCount;
+				newValue = this._calculateNewValue(sectionGroup.overrideSectionCount, isReversion);
 				newSectionGroupCost.sectionCount = sectionGroup.overrideSectionCount;
 			}
 
 			else if (property == "teachingAssistantAppointments") {
 				savedOverride = sectionGroup.sectionGroupCost ? sectionGroup.sectionGroupCost.taCount : null;
 				oldValue = savedOverride || sectionGroup.teachingAssistantAppointments;
-				newValue = sectionGroup.overrideTeachingAssistantAppointments;
+				newValue = this._calculateNewValue(sectionGroup.overrideTeachingAssistantAppointments, isReversion);
 				newSectionGroupCost.taCount = sectionGroup.overrideTeachingAssistantAppointments;
 			}
 
 			else if (property == "readerAppointments") {
 				savedOverride = sectionGroup.sectionGroupCost ? sectionGroup.sectionGroupCost.readerCount : null;
 				oldValue = savedOverride || sectionGroup.readerAppointments;
-				newValue = sectionGroup.overrideReaderAppointments;
+				newValue = this._calculateNewValue(sectionGroup.overrideReaderAppointments, isReversion);
 				newSectionGroupCost.readerCount = sectionGroup.overrideReaderAppointments;
 			}
 
@@ -111,6 +110,12 @@ budgetApp.service('budgetActions', function ($rootScope, $window, budgetService,
 				// Do nothing
 				return;
 			}
+		},
+		// When reverting to schedule data, null should be sent to backend.
+		// However, if user emptied the input we should treat that as setting the override to an explicit value of 0.
+		_calculateNewValue: function (newValue, isReversion) {
+			debugger;
+			return isReversion ? newValue : newValue || 0;
 		},
 		applyOverrideToProperty: function (sectionGroupCost, value, property) {
 			if (property == "seats") {

--- a/app/budget/services/actions/budgetActions.js
+++ b/app/budget/services/actions/budgetActions.js
@@ -112,9 +112,8 @@ budgetApp.service('budgetActions', function ($rootScope, $window, budgetService,
 			}
 		},
 		// When reverting to schedule data, null should be sent to backend.
-		// However, if user emptied the input we should treat that as setting the override to an explicit value of 0.
+		// However, if user emptied the input it should be treated as explicitly setting an override of 0.
 		_calculateNewValue: function (newValue, isReversion) {
-			debugger;
 			return isReversion ? newValue : newValue || 0;
 		},
 		applyOverrideToProperty: function (sectionGroupCost, value, property) {

--- a/app/shared/directives/ipaInput/ipaInput.html
+++ b/app/shared/directives/ipaInput/ipaInput.html
@@ -6,7 +6,6 @@
 		placeholder="{{placeHolder}}"
 		ng-readonly="readOnly"
 		ng-keyup="updateInput()"
-		type="{{ mode == 'number' ? 'number' : ''}}"
 		ng-class="{'ipa-input--read-only': readOnly }">
 
 	<input class="ipa-input"
@@ -17,6 +16,5 @@
 		placeholder="{{placeHolder}}"
 		ng-readonly="readOnly"
 		ng-keyup="updateInput()"
-		type="{{ mode == 'number' ? 'number' : ''}}"
 		ng-class="{'ipa-input--read-only': readOnly }">
 </div>

--- a/app/shared/directives/ipaInput/ipaInput.js
+++ b/app/shared/directives/ipaInput/ipaInput.js
@@ -25,7 +25,7 @@ sharedApp.directive("ipaInput", this.ipaInput = function ($timeout) {
 					var PERIOD = 140;
 					var BACK_SPACE = 8;
 
-					if (isNumericKeyCode(e.keyCode) == false
+					if (scope.isNumericKeyCode(e.keyCode) == false
 					&& e.keyCode != PERIOD
 					&& e.keyCode != BACK_SPACE) {
 						e.preventDefault();
@@ -37,7 +37,7 @@ sharedApp.directive("ipaInput", this.ipaInput = function ($timeout) {
 			scope.isNumericKeyCode = function (keyCode) {
 				// Numbers on top of keyboard are keyCodes: 48 - 57
 				// Numbers on keypad are keyCodes: 96 - 105
-				return (e.keyCode >= 48 && e.keyCode <= 57) || (e.keyCode >= 96 && e.keyCode <= 105);
+				return (keyCode >= 48 && keyCode <= 57) || (keyCode >= 96 && keyCode <= 105);
 			};
 
 			// Main method triggered by template, handles filtering/update callback

--- a/app/shared/directives/ipaInput/ipaInput.js
+++ b/app/shared/directives/ipaInput/ipaInput.js
@@ -12,6 +12,34 @@ sharedApp.directive("ipaInput", this.ipaInput = function ($timeout) {
 			mode: '<?' // Options are 'number' (only allow characters 0-9), and 'currency' (currency style formatting and input enforcement)
 		},
 		link: function(scope, element, attrs) {
+
+			scope.$watch('mode',function() {
+				if (scope.mode && scope.mode == 'number') {
+					scope.onlyAllowNumberInputs();
+				}
+			});
+
+			// Limits input to: backspace, period, and 0-9.
+			scope.onlyAllowNumberInputs = function() {
+				element.on('keydown', function (e) {
+					var PERIOD = 140;
+					var BACK_SPACE = 8;
+
+					if (isNumericKeyCode(e.keyCode) == false
+					&& e.keyCode != PERIOD
+					&& e.keyCode != BACK_SPACE) {
+						e.preventDefault();
+					}
+				});
+			};
+
+			// Returns true if keyCode falls within one of the two numeric ranges.
+			scope.isNumericKeyCode = function (keyCode) {
+				// Numbers on top of keyboard are keyCodes: 48 - 57
+				// Numbers on keypad are keyCodes: 96 - 105
+				return (e.keyCode >= 48 && e.keyCode <= 57) || (e.keyCode >= 96 && e.keyCode <= 105);
+			};
+
 			// Main method triggered by template, handles filtering/update callback
 			scope.updateInput = function() {
 				scope.applyUpdate();


### PR DESCRIPTION
Note: I've pointed this merge directly to master as I would like to merge it quickly.
The fix is fairly small, and the arrows have been disruptive for econ/psych and others testing the budget module who use firefox. The arrows cover over half of the input on TA/reader/section/etc, which are narrow inputs by design.

Issue:
https://trello.com/c/PdY8UQXR/1594-budget-arrows-on-number-field-are-not-being-properly-hidden-in-firefox