### PR TITLE
SchedulingView: Fix section selection color changing behavior with tags

### DIFF
--- a/app/scheduling/directives/termCalendar.js
+++ b/app/scheduling/directives/termCalendar.js
@@ -49,7 +49,8 @@ schedulingApp.directive("termCalendar", this.termCalendar = function ($rootScope
 			var unavailabilityEventTextColor = "#555555";
 
 			var tagEventTextColor = "#FFFFFF";
-			var selectedActivityTaggedColorShift = .6;
+			// This will be used to 'darken' the color of a card on the calendar if it has a user specified 'tag' color
+			var selectedActivityTintingMultiplier = .6;
 
 			var refreshCalendar = function () {
 				var parentAspectRatio = element.parent().width() / element.parent().height();
@@ -108,8 +109,8 @@ schedulingApp.directive("termCalendar", this.termCalendar = function ($rootScope
 			};
 
 			// Supply a color and amount to shift the color (out of 255)
-			// Example to lighten: lightenOrDarkenColor("#F06D06", 20);
-			// Example to darken: lightenOrDarkenColor("#F06D06", -20);
+			// Example to lighten: lightenOrDarkenColor("#F06D06", 1.2);
+			// Example to darken: lightenOrDarkenColor("#F06D06", .6);
 			var lightenOrDarkenColor = function(hexColor, amt) {
 				var rgbValues = hexToRgb(hexColor);
 
@@ -121,6 +122,7 @@ schedulingApp.directive("termCalendar", this.termCalendar = function ($rootScope
 			};
 
 			// Converts a piece of the rgb value to its hex equivalent
+			// Example: rgbComponentToHex(110) -> "6e"
 			function rgbComponentToHex(c) {
 				var hex = c.toString(16);
 				return hex.length == 1 ? "0" + hex : hex;
@@ -131,11 +133,16 @@ schedulingApp.directive("termCalendar", this.termCalendar = function ($rootScope
 			}
 
 			function hexToRgb(hex) {
-				var result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
-				return result ? {
-					r: parseInt(result[1], 16),
-					g: parseInt(result[2], 16),
-					b: parseInt(result[3], 16)
+				var expandedHex = {
+					r: hex.slice(1, 3),
+					g: hex.slice(3,5),
+					b: hex.slice(5,7)
+				};
+
+				return expandedHex ? {
+					r: parseInt(expandedHex.r, 16),
+					b: parseInt(expandedHex.b, 16),
+					g: parseInt(expandedHex.g, 16)
 				} : null;
 			}
 
@@ -310,8 +317,8 @@ schedulingApp.directive("termCalendar", this.termCalendar = function ($rootScope
 				calendarActivities.forEach(function (event) {
 					if (scope.view.state.uiState.selectedActivityId === event.activityId) {
 						if (tagColor) {
-							event.color = lightenOrDarkenColor(tagColor, selectedActivityTaggedColorShift);
-							event.borderColor = lightenOrDarkenColor(tagColor, selectedActivityTaggedColorShift);
+							event.color = lightenOrDarkenColor(tagColor, selectedActivityTintingMultiplier);
+							event.borderColor = lightenOrDarkenColor(tagColor, selectedActivityTintingMultiplier);
 							event.textColor = textColor;
 						} else {
 							event.color = highlightedEventBackgroundColor;

--- a/app/scheduling/directives/termCalendar.js
+++ b/app/scheduling/directives/termCalendar.js
@@ -49,7 +49,7 @@ schedulingApp.directive("termCalendar", this.termCalendar = function ($rootScope
 			var unavailabilityEventTextColor = "#555555";
 
 			var tagEventTextColor = "#FFFFFF";
-			var selectedActivityTaggedColorShift = -80;
+			var selectedActivityTaggedColorShift = .6;
 
 			var refreshCalendar = function () {
 				var parentAspectRatio = element.parent().width() / element.parent().height();
@@ -106,6 +106,38 @@ schedulingApp.directive("termCalendar", this.termCalendar = function ($rootScope
 					}
 				});
 			};
+
+			// Supply a color and amount to shift the color (out of 255)
+			// Example to lighten: lightenOrDarkenColor("#F06D06", 20);
+			// Example to darken: lightenOrDarkenColor("#F06D06", -20);
+			var lightenOrDarkenColor = function(hexColor, amt) {
+				var rgbValues = hexToRgb(hexColor);
+
+				var r = parseInt(rgbValues.r * amt);
+				var g = parseInt(rgbValues.g * amt);
+				var b = parseInt(rgbValues.b * amt);
+
+				return rgbToHex(r, g, b);
+			};
+
+			// Converts a piece of the rgb value to its hex equivalent
+			function rgbComponentToHex(c) {
+				var hex = c.toString(16);
+				return hex.length == 1 ? "0" + hex : hex;
+			}
+
+			function rgbToHex(r, g, b) {
+				return "#" + rgbComponentToHex(r) + rgbComponentToHex(g) + rgbComponentToHex(b);
+			}
+
+			function hexToRgb(hex) {
+				var result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+				return result ? {
+					r: parseInt(result[1], 16),
+					g: parseInt(result[2], 16),
+					b: parseInt(result[3], 16)
+				} : null;
+			}
 
 			var getActivities = function () {
 				// Each of these If blocks will add to a 'events array'
@@ -277,9 +309,15 @@ schedulingApp.directive("termCalendar", this.termCalendar = function ($rootScope
 			var styleCalendarEvents = function (calendarActivities, backgroundColor, borderColor, textColor, tagColor) {
 				calendarActivities.forEach(function (event) {
 					if (scope.view.state.uiState.selectedActivityId === event.activityId) {
+						if (tagColor) {
+							event.color = lightenOrDarkenColor(tagColor, selectedActivityTaggedColorShift);
+							event.borderColor = lightenOrDarkenColor(tagColor, selectedActivityTaggedColorShift);
+							event.textColor = textColor;
+						} else {
 							event.color = highlightedEventBackgroundColor;
 							event.borderColor = highlightedEventBorderColor;
 							event.textColor = highlightedEventTextColor;
+						}
 					} else {
 						event.color = angular.copy(backgroundColor);
 						event.borderColor = angular.copy(borderColor);

--- a/app/scheduling/directives/termCalendar.js
+++ b/app/scheduling/directives/termCalendar.js
@@ -107,43 +107,6 @@ schedulingApp.directive("termCalendar", this.termCalendar = function ($rootScope
 				});
 			};
 
-			// Supply a color and amount to shift the color (out of 255)
-			// Example to lighten: lightenOrDarkenColor("#F06D06", 20);
-			// Example to darken: lightenOrDarkenColor("#F06D06", -20);
-			var lightenOrDarkenColor = function(col, amt) {
-				var usePound = false;
-
-				if (col[0] == "#") {
-					col = col.slice(1);
-					usePound = true;
-				}
-
-				var num = parseInt(col,16);
-				var r = (num >> 16) + amt;
-
-				if (r > 255) {
-					r = 255;
-				} else if (r < 0) {
-					r = 0;
-				}
-
-				var b = ((num >> 8) & 0x00FF) + amt;
-
-				if (b > 255) {
-					b = 255;
-				} else if (b < 0) { b = 0; }
-
-				var g = (num & 0x0000FF) + amt;
-
-				if (g > 255) {
-					g = 255;
-				} else if (g < 0) {
-					g = 0;
-				}
-
-				return (usePound ? "#" : "") + (g | (b << 8) | (r << 16)).toString(16);
-			};
-
 			var getActivities = function () {
 				// Each of these If blocks will add to a 'events array'
 				// The event making function will color them appropriately
@@ -314,15 +277,9 @@ schedulingApp.directive("termCalendar", this.termCalendar = function ($rootScope
 			var styleCalendarEvents = function (calendarActivities, backgroundColor, borderColor, textColor, tagColor) {
 				calendarActivities.forEach(function (event) {
 					if (scope.view.state.uiState.selectedActivityId === event.activityId) {
-						if (tagColor) {
-							event.color = lightenOrDarkenColor(tagColor, selectedActivityTaggedColorShift);
-							event.borderColor = lightenOrDarkenColor(tagColor, selectedActivityTaggedColorShift);
-							event.textColor = textColor;
-						} else {
 							event.color = highlightedEventBackgroundColor;
 							event.borderColor = highlightedEventBorderColor;
 							event.textColor = highlightedEventTextColor;
-						}
 					} else {
 						event.color = angular.copy(backgroundColor);
 						event.borderColor = angular.copy(borderColor);


### PR DESCRIPTION
Issue:
https://trello.com/c/ZPylayNq/1626-scheduling-view-bug-in-display-of-activities

Problem:
If a course had the 'graduate' tag, and you selected a section from that course, it would become entirely white (but still present on the calendar, you could see small artifacts, and could hover over the element, and see the html for it).

This behavior did not manifest with other tags, just the 'graduate' tag.

I eventually tracked it down to a malfunctioning darkening/lightening function. For particular color ranges, the lighten/darken method would incorrectly generate the hex color and it would end up being interpreted by the browser as having an alpha value of zero. (The color picked by school of ed for the 'graduate' tag, fell in this color range).

In these cases, due to the way tinting was expressed as adding integer values, it allowed numbers to become negative, and the method was not properly handling zero padding in those cases.

To resolve this I replaced the function with much clearer to understand hextToRgb and rgbToHex logic