### PR TITLE
Upgrade to angularJs 1.6.9

### DIFF
--- a/app/admin/services/adminService.js
+++ b/app/admin/services/adminService.js
@@ -6,59 +6,19 @@
  * Service in the adminApp.
  * adminApp specific api calls.
  */
-adminApp.factory("adminService", this.adminService = function($http, $q) {
+adminApp.factory("adminService", this.adminService = function($http, $q, apiService) {
 	return {
 		getAdminView: function() {
-			var deferred = $q.defer();
-
-			$http.get(serverRoot + "/api/adminView", { withCredentials: true })
-			.success(function(payload) {
-				deferred.resolve(payload);
-			})
-			.error(function() {
-				deferred.reject();
-			});
-
-			return deferred.promise;
+			return apiService.get("/api/adminView");
 		},
 		updateWorkgroup: function(workgroup) {
-			var deferred = $q.defer();
-
-			$http.put(serverRoot + "/api/adminView/workgroups/" + workgroup.id, workgroup, { withCredentials: true })
-			.success(function(workgroup) {
-				deferred.resolve(workgroup);
-			})
-			.error(function() {
-				deferred.reject();
-			});
-
-			return deferred.promise;
+			return apiService.put("/api/adminView/workgroups/" + workgroup.id, workgroup);
 		},
 		removeWorkgroup: function(workgroupId) {
-			var deferred = $q.defer();
-
-			$http.delete(serverRoot + "/api/adminView/workgroups/" + workgroupId, { withCredentials: true })
-			.success(function() {
-				deferred.resolve();
-			})
-			.error(function() {
-				deferred.reject();
-			});
-
-			return deferred.promise;
+			return apiService.delete("/api/adminView/workgroups/" + workgroupId);
 		},
 		addWorkgroup: function(workgroup) {
-			var deferred = $q.defer();
-
-			$http.post(serverRoot + "/api/adminView/workgroups", workgroup, { withCredentials: true })
-			.success(function(workgroup) {
-				deferred.resolve(workgroup);
-			})
-			.error(function() {
-				deferred.reject();
-			});
-
-			return deferred.promise;
+			return apiService.post("/api/adminView/workgroups", workgroup);
 		}
 	};
 });

--- a/app/admin/services/adminService.js
+++ b/app/admin/services/adminService.js
@@ -6,7 +6,7 @@
  * Service in the adminApp.
  * adminApp specific api calls.
  */
-adminApp.factory("adminService", this.adminService = function($http, $q, apiService) {
+adminApp.factory("adminService", this.adminService = function(apiService) {
 	return {
 		getAdminView: function() {
 			return apiService.get("/api/adminView");

--- a/app/assignment/controllers/AssignmentCtrl.js
+++ b/app/assignment/controllers/AssignmentCtrl.js
@@ -78,54 +78,6 @@ assignmentApp.controller('AssignmentCtrl', ['$scope', '$rootScope', '$window', '
 				assignmentActionCreators.updateTagFilters(tagFilters);
 			};
 
-			// Launches TeachingCall Config modal and controller
-			$scope.openTeachingCallConfig = function() {
-				modalInstance = $uibModal.open({
-					templateUrl: 'ModalTeachingCallConfig.html',
-					controller: ModalTeachingCallConfigCtrl,
-					size: 'lg',
-					resolve: {
-						scheduleYear: function () {
-							return $scope.year;
-						},
-						workgroupId: function () {
-							return $scope.workgroupId;
-						},
-						viewState: function () {
-							return $scope.view.state;
-						},
-						allTerms: function () {
-							return assignmentService.allTerms();
-						}
-					}
-				});
-
-				modalInstance.result.then(function (teachingCallConfig) {
-					$scope.startTeachingCall($scope.workgroupId, $scope.year, teachingCallConfig);
-				},
-				function () {
-					// Modal closed
-				});
-			};
-
-			// Triggered on TeachingCall Config submission
-			$scope.startTeachingCall = function(workgroupId, year, teachingCallConfig) {
-				teachingCallConfig.termsBlob = "";
-				var allTerms = ['05','06','07','08','09','10','01','02','03'];
-
-				for (var i = 0; i < allTerms.length; i++) {
-					if (teachingCallConfig.activeTerms[allTerms[i]] === true) {
-						teachingCallConfig.termsBlob += "1";
-					} else {
-						teachingCallConfig.termsBlob += "0";
-					}
-				}
-
-				delete teachingCallConfig.activeTerms;
-
-				assignmentActionCreators.createTeachingCall(workgroupId, year, teachingCallConfig);
-			};
-
 			// Launched from the instructorTable directive UI handler
 			$scope.openCommentModal = function(instructorId) {
 				var instructor = $scope.view.state.instructors.list[instructorId];
@@ -209,6 +161,13 @@ assignmentApp.controller('AssignmentCtrl', ['$scope', '$rootScope', '$window', '
 							return instructor;
 						}
 					}
+				});
+
+				modalInstance.result.then(function () {
+					// This modal does not 'submit' in a traditional sense.
+				},
+				function () {
+					// Modal closed
 				});
 			};
 

--- a/app/assignment/controllers/AssignmentCtrl.js
+++ b/app/assignment/controllers/AssignmentCtrl.js
@@ -102,6 +102,9 @@ assignmentApp.controller('AssignmentCtrl', ['$scope', '$rootScope', '$window', '
 
 				modalInstance.result.then(function (teachingCallConfig) {
 					$scope.startTeachingCall($scope.workgroupId, $scope.year, teachingCallConfig);
+				},
+				function () {
+					// Modal closed
 				});
 			};
 
@@ -180,6 +183,9 @@ assignmentApp.controller('AssignmentCtrl', ['$scope', '$rootScope', '$window', '
 							assignmentActionCreators.addScheduleInstructorNote(instructor.id, $scope.year, $scope.workgroupId, privateComment);
 						}
 					}
+				},
+				function () {
+					// Modal closed
 				});
 			};
 

--- a/app/assignment/services/assignmentService.js
+++ b/app/assignment/services/assignmentService.js
@@ -9,229 +9,61 @@
 assignmentApp.factory("assignmentService", this.assignmentService = function($http, $q, $window) {
 	return {
 		getInitialState: function(workgroupId, year) {
-			var deferred = $q.defer();
-
-			$http.get(serverRoot + "/api/assignmentView/" + workgroupId + "/" + year, { withCredentials: true })
-			.success(function(assignmentView) {
-				deferred.resolve(assignmentView);
-			})
-			.error(function() {
-				deferred.reject();
-			});
-
-			return deferred.promise;
+			return apiService.get("/api/assignmentView/" + workgroupId + "/" + year);
 		},
 		download: function (workgroupId, year) {
-			var deferred = $q.defer();
-
-			$http.get(serverRoot + "/api/assignmentView/workgroups/" + workgroupId + "/years/" + year + "/generateExcel", { withCredentials: true })
-			.success(function(payload) {
-				$window.location.href = payload.redirect;
-				deferred.resolve(payload);
-			})
-			.error(function() {
-				deferred.reject();
-			});
-
-			return deferred.promise;
+			return apiService.get("/api/assignmentView/workgroups/" + workgroupId + "/years/" + year + "/generateExcel");
 		},
 		updateSectionGroup: function (sectionGroup) {
-			var deferred = $q.defer();
-
-			$http.put(serverRoot + "/api/courseView/sectionGroups/" + sectionGroup.id, sectionGroup, { withCredentials: true })
-			.success(function(payload) {
-				deferred.resolve(payload);
-			})
-			.error(function() {
-				deferred.reject();
-			});
-
-			return deferred.promise;
+			return apiService.put("/api/courseView/sectionGroups/" + sectionGroup.id, sectionGroup);
 		},
 		createTeachingCall: function (workgroupId, year, teachingCallConfig) {
-			var deferred = $q.defer();
-
-			$http.post(serverRoot + "/api/assignmentView/" + workgroupId + "/" + year + "/teachingCalls", teachingCallConfig, { withCredentials: true })
-			.success(function(payload) {
-				deferred.resolve(payload);
-			})
-			.error(function() {
-				deferred.reject();
-			});
-
-			return deferred.promise;
+			return apiService.post("/api/assignmentView/" + workgroupId + "/" + year + "/teachingCalls", teachingCallConfig);
 		},
 		addPreference: function (teachingAssignment) {
-			var deferred = $q.defer();
-
-			$http.post(serverRoot + "/api/assignmentView/preferences/" + teachingAssignment.schedule.id, teachingAssignment, { withCredentials: true })
-			.success(function(payload) {
-				deferred.resolve(payload);
-			})
-			.error(function() {
-				deferred.reject();
-			});
-
-			return deferred.promise;
+			return apiService.post("/api/assignmentView/preferences/" + teachingAssignment.schedule.id, teachingAssignment);
 		},
 		removePreference: function (teachingAssignment) {
-			var deferred = $q.defer();
-
-			$http.delete(serverRoot + "/api/assignmentView/preferences/" + teachingAssignment.id, { withCredentials: true })
-			.success(function(payload) {
-				deferred.resolve(payload);
-			})
-			.error(function() {
-				deferred.reject();
-			});
-
-			return deferred.promise;
+			return apiService.delete("/api/assignmentView/preferences/" + teachingAssignment.id);
 		},
 		deleteTeachingCall: function (teachingCall) {
-			var deferred = $q.defer();
-
-			$http.delete(serverRoot + "/api/assignmentView/teachingCalls/" + teachingCall.id, { withCredentials: true })
-			.success(function(payload) {
-				deferred.resolve(payload);
-			})
-			.error(function() {
-				deferred.reject();
-			});
-
-			return deferred.promise;
+			return apiService.delete("/api/assignmentView/teachingCalls/" + teachingCall.id);
 		},
 		addInstructorAssignment: function (teachingAssignment, scheduleId) {
-			var deferred = $q.defer();
 			teachingAssignment.termCode = String(teachingAssignment.termCode);
-			$http.post(serverRoot + "/api/assignmentView/schedules/" + scheduleId + "/teachingAssignments", teachingAssignment, { withCredentials: true })
-			.success(function(payload) {
-				deferred.resolve(payload);
-			})
-			.error(function() {
-				deferred.reject();
-			});
 
-			return deferred.promise;
+			return apiService.post("/api/assignmentView/schedules/" + scheduleId + "/teachingAssignments", teachingAssignment);
 		},
 		updateInstructorAssignment: function (teachingAssignment) {
-			var deferred = $q.defer();
-
-			$http.put(serverRoot + "/api/assignmentView/teachingAssignments/" + teachingAssignment.id, teachingAssignment, { withCredentials: true })
-			.success(function(payload) {
-				deferred.resolve(payload);
-			})
-			.error(function() {
-				deferred.reject();
-			});
-
-			return deferred.promise;
+			return apiService.put("/api/assignmentView/teachingAssignments/" + teachingAssignment.id, teachingAssignment);
 		},
 		addScheduleInstructorNote: function (instructorId, year, workgroupId, comment, assignmentsCompleted) {
-			var deferred = $q.defer();
 			var scheduleInstructorNote = {};
 			scheduleInstructorNote.instructorComment = comment;
 			scheduleInstructorNote.assignmentsCompleted = assignmentsCompleted;
 
-			$http.post(serverRoot + "/api/assignmentView/scheduleInstructorNotes/" + instructorId + "/" + workgroupId + "/" + year, scheduleInstructorNote, { withCredentials: true })
-			.success(function(payload) {
-				deferred.resolve(payload);
-			})
-			.error(function() {
-				deferred.reject();
-			});
-
-			return deferred.promise;
+			return apiService.post("/api/assignmentView/scheduleInstructorNotes/" + instructorId + "/" + workgroupId + "/" + year, scheduleInstructorNote);
 		},
 		assignStudentToAssociateInstructor: function (sectionGroupId, supportStaffId) {
-			var deferred = $q.defer();
-
-			$http.post(serverRoot + "/api/assignmentView/sectionGroups/" + sectionGroupId + "/supportStaff/" + supportStaffId + "/assignAI", { withCredentials: true })
-			.success(function(payload) {
-				deferred.resolve(payload);
-			})
-			.error(function() {
-				deferred.reject();
-			});
-
-			return deferred.promise;
+			return apiService.post("/api/assignmentView/sectionGroups/" + sectionGroupId + "/supportStaff/" + supportStaffId + "/assignAI");
 		},
 		updateScheduleInstructorNote: function (scheduleInstructorNote) {
-			var deferred = $q.defer();
-
-			$http.put(serverRoot + "/api/assignmentView/scheduleInstructorNotes/" + scheduleInstructorNote.id, scheduleInstructorNote, { withCredentials: true })
-			.success(function(payload) {
-				deferred.resolve(payload);
-			})
-			.error(function() {
-				deferred.reject();
-			});
-
-			return deferred.promise;
+			return apiService.put("/api/assignmentView/scheduleInstructorNotes/" + scheduleInstructorNote.id, scheduleInstructorNote);
 		},
 		updateAssignmentsOrder: function (sortedTeachingAssignmentIds, scheduleId) {
-			var deferred = $q.defer();
-
-			$http.put(serverRoot + "/api/assignmentView/schedules/" + scheduleId + "/teachingAssignments" , sortedTeachingAssignmentIds, { withCredentials: true })
-			.success(function(payload) {
-				deferred.resolve(payload);
-			})
-			.error(function() {
-				deferred.reject();
-			});
-
-			return deferred.promise;
+			return apiService.put("/api/assignmentView/schedules/" + scheduleId + "/teachingAssignments" , sortedTeachingAssignmentIds);
 		},
 		updateTeachingCallResponse: function (teachingCallResponse) {
-			var deferred = $q.defer();
-
-			$http.put(serverRoot + "/api/assignmentView/teachingCallResponses/" + teachingCallResponse.id, teachingCallResponse, { withCredentials: true })
-			.success(function(payload) {
-				deferred.resolve(payload);
-			})
-			.error(function() {
-				deferred.reject();
-			});
-
-			return deferred.promise;
+			return apiService.put("/api/assignmentView/teachingCallResponses/" + teachingCallResponse.id, teachingCallResponse);
 		},
 		addTeachingCallResponse: function (teachingCallResponse) {
-			var deferred = $q.defer();
-
-			$http.post(serverRoot + "/api/assignmentView/teachingCallResponses/" + teachingCallResponse.scheduleId  + "/" + teachingCallResponse.instructorId, teachingCallResponse, { withCredentials: true })
-			.success(function(payload) {
-				deferred.resolve(payload);
-			})
-			.error(function() {
-				deferred.reject();
-			});
-
-			return deferred.promise;
+			return apiService.post("/api/assignmentView/teachingCallResponses/" + teachingCallResponse.scheduleId  + "/" + teachingCallResponse.instructorId, teachingCallResponse);
 		},
 		updateTeachingCallReceipt: function (teachingCallReceipt) {
-			var deferred = $q.defer();
-
-			$http.put(serverRoot + "/api/assignmentView/teachingCallReceipts/" + teachingCallReceipt.id, teachingCallReceipt, { withCredentials: true })
-			.success(function(payload) {
-				deferred.resolve(payload);
-			})
-			.error(function() {
-				deferred.reject();
-			});
-
-			return deferred.promise;
+			return apiService.put("/api/assignmentView/teachingCallReceipts/" + teachingCallReceipt.id, teachingCallReceipt);
 		},
 		searchCourses: function(query) {
-			var deferred = $q.defer();
-
-			$http.get(dwUrl + "/courses/search?q=" + query + "&token=" + dwToken)
-			.success(function(result) {
-				deferred.resolve(result);
-			})
-			.error(function() {
-				deferred.reject();
-			});
-
-			return deferred.promise;
+			return apiService.get("/courses/search?q=" + query + "&token=" + dwToken, null, dwUrl);
 		},
 		allTerms: function () {
 			var allTerms = {

--- a/app/assignment/services/assignmentService.js
+++ b/app/assignment/services/assignmentService.js
@@ -6,7 +6,7 @@
  * Service in the workgroupApp.
  * workgroupApp specific api calls.
  */
-assignmentApp.factory("assignmentService", this.assignmentService = function($http, $q, $window) {
+assignmentApp.factory("assignmentService", this.assignmentService = function(apiService) {
 	return {
 		getInitialState: function(workgroupId, year) {
 			return apiService.get("/api/assignmentView/" + workgroupId + "/" + year);

--- a/app/budget/services/budgetService.js
+++ b/app/budget/services/budgetService.js
@@ -1,4 +1,4 @@
-budgetApp.factory("budgetService", this.budgetService = function($http, $q, $window, apiService) {
+budgetApp.factory("budgetService", this.budgetService = function(apiService) {
 	return {
 		// Page load
 		getInitialState: function(workgroupId, year) {

--- a/app/course/services/courseService.js
+++ b/app/course/services/courseService.js
@@ -13,10 +13,10 @@ courseApp.factory("courseService", this.courseService = function ($http, $q, $wi
 			var showDoNotPrintParam = enableUnpublishedCourses ? "?showDoNotPrint=true" : "";
 
 			$http.get(serverRoot + "/api/courseView/workgroups/" + workgroupId + "/years/" + year + showDoNotPrintParam, { withCredentials: true })
-				.success(function (payload) {
-					deferred.resolve(payload);
-				})
-				.error(function () {
+				.then(function (response) {
+					deferred.resolve(response.data);
+				},
+				function () {
 					deferred.reject();
 				});
 
@@ -27,11 +27,11 @@ courseApp.factory("courseService", this.courseService = function ($http, $q, $wi
 			var showDoNotPrintParam = enableUnpublishedCourses ? "?showDoNotPrint=true" : "";
 
 			$http.get(serverRoot + "/api/courseView/workgroups/" + workgroupId + "/years/" + year + "/generateExcel" + showDoNotPrintParam, { withCredentials: true })
-				.success(function (payload) {
-					$window.location.href = payload.redirect;
+				.then(function (response) {
+					$window.location.href = response.data.redirect;
 					deferred.resolve(payload);
-				})
-				.error(function () {
+				},
+				function () {
 					deferred.reject();
 				});
 
@@ -41,10 +41,10 @@ courseApp.factory("courseService", this.courseService = function ($http, $q, $wi
 			var deferred = $q.defer();
 
 			$http.post(serverRoot + "/api/courseView/sectionGroups/", sectionGroup, { withCredentials: true })
-				.success(function (payload) {
-					deferred.resolve(payload);
-				})
-				.error(function () {
+				.then(function (response) {
+					deferred.resolve(response.data);
+				},
+				function () {
 					deferred.reject();
 				});
 
@@ -55,10 +55,10 @@ courseApp.factory("courseService", this.courseService = function ($http, $q, $wi
 			if (!sectionGroup) { return; }
 
 			$http.put(serverRoot + "/api/courseView/sectionGroups/" + sectionGroup.id, sectionGroup, { withCredentials: true })
-				.success(function (payload) {
-					deferred.resolve(payload);
-				})
-				.error(function () {
+				.then(function (response) {
+					deferred.resolve(response.data);
+				},
+				function () {
 					deferred.reject();
 				});
 
@@ -68,10 +68,10 @@ courseApp.factory("courseService", this.courseService = function ($http, $q, $wi
 			var deferred = $q.defer();
 
 			$http.delete(serverRoot + "/api/courseView/sectionGroups/" + sectionGroupId, { withCredentials: true })
-				.success(function (payload) {
-					deferred.resolve(payload);
-				})
-				.error(function () {
+				.then(function (response) {
+					deferred.resolve(response.data);
+				},
+				function () {
 					deferred.reject();
 				});
 
@@ -91,10 +91,10 @@ courseApp.factory("courseService", this.courseService = function ($http, $q, $wi
 			}
 
 			$http.post(serverRoot + "/api/courseView/workgroups/" + workgroupId + "/years/" + year + "/courses", course, { withCredentials: true })
-				.success(function (payload) {
-					deferred.resolve(payload);
-				})
-				.error(function () {
+				.then(function (response) {
+					deferred.resolve(response.data);
+				},
+				function () {
 					deferred.reject();
 				});
 
@@ -104,10 +104,10 @@ courseApp.factory("courseService", this.courseService = function ($http, $q, $wi
 			var deferred = $q.defer();
 
 			$http.post(serverRoot + "/api/courseView/workgroups/" + workgroupId + "/years/" + year + "/sectionGroups?importTimes=" + importTimes + "&importAssignments=" + importAssignments, sectionGroupImports, { withCredentials: true })
-				.success(function (payload) {
-					deferred.resolve(payload);
-				})
-				.error(function () {
+				.then(function (response) {
+					deferred.resolve(response.data);
+				},
+				function () {
 					deferred.reject();
 				});
 
@@ -117,10 +117,10 @@ courseApp.factory("courseService", this.courseService = function ($http, $q, $wi
 			var deferred = $q.defer();
 
 			$http.post(serverRoot + "/api/courseView/workgroups/" + workgroupId + "/years/" + year + "/createCourses?importTimes=" + importTimes + "&importAssignments=" + importAssignments, sectionGroupImports, { withCredentials: true })
-				.success(function (payload) {
-					deferred.resolve(payload);
-				})
-				.error(function () {
+				.then(function (response) {
+					deferred.resolve(response.data);
+				},
+				function () {
 					deferred.reject();
 				});
 
@@ -131,10 +131,10 @@ courseApp.factory("courseService", this.courseService = function ($http, $q, $wi
 			if (!course) { return; }
 
 			$http.put(serverRoot + "/api/courseView/courses/" + course.id, course, { withCredentials: true })
-				.success(function (payload) {
-					deferred.resolve(payload);
-				})
-				.error(function () {
+				.then(function (response) {
+					deferred.resolve(response.data);
+				},
+				function () {
 					deferred.reject();
 				});
 
@@ -145,10 +145,10 @@ courseApp.factory("courseService", this.courseService = function ($http, $q, $wi
 			if (!course) { return; }
 
 			$http.delete(serverRoot + "/api/courseView/courses/" + course.id, { withCredentials: true })
-				.success(function (payload) {
-					deferred.resolve(payload);
-				})
-				.error(function () {
+				.then(function (response) {
+					deferred.resolve(response.data);
+				},
+				function () {
 					deferred.reject();
 				});
 
@@ -158,10 +158,10 @@ courseApp.factory("courseService", this.courseService = function ($http, $q, $wi
 			var deferred = $q.defer();
 
 			$http.put(serverRoot + "/api/courseView/schedules/" + workgroupId + "/" + year + "/courses", courseIds, { withCredentials: true })
-				.success(function (payload) {
-					deferred.resolve(payload);
-				})
-				.error(function () {
+				.then(function (response) {
+					deferred.resolve(response.data);
+				},
+				function () {
 					deferred.reject();
 				});
 
@@ -171,10 +171,10 @@ courseApp.factory("courseService", this.courseService = function ($http, $q, $wi
 			var deferred = $q.defer();
 
 			$http.put(serverRoot + "/api/courseView/workgroups/" + workgroupId + "/years/" + year + "/massAddTags", massAssignTags, { withCredentials: true })
-				.success(function (payload) {
-					deferred.resolve(payload);
-				})
-				.error(function () {
+				.then(function (response) {
+					deferred.resolve(response.data);
+				},
+				function () {
 					deferred.reject();
 				});
 
@@ -184,10 +184,10 @@ courseApp.factory("courseService", this.courseService = function ($http, $q, $wi
 			var deferred = $q.defer();
 
 			$http.get(dwUrl + "/courses/search?q=" + query + "&token=" + dwToken)
-				.success(function (result) {
-					deferred.resolve(result);
-				})
-				.error(function () {
+				.then(function (response) {
+					deferred.resolve(response.data);
+				},
+				function () {
 					deferred.reject();
 				});
 
@@ -198,10 +198,10 @@ courseApp.factory("courseService", this.courseService = function ($http, $q, $wi
 			var privateParam = includePrivate ? "&private=true" : "";
 
 			$http.get(dwUrl + "/sections/search?subjectCode=" + subjectCode + "&academicYear=" + year + "&token=" + dwToken + privateParam)
-				.success(function (result) {
-					deferred.resolve(result);
-				})
-				.error(function () {
+				.then(function (response) {
+					deferred.resolve(response.data);
+				},
+				function () {
 					deferred.reject();
 				});
 
@@ -212,10 +212,10 @@ courseApp.factory("courseService", this.courseService = function ($http, $q, $wi
 			if (!course) { return; }
 
 			$http.post(serverRoot + "/api/courseView/courses/" + course.id + "/tags/" + tag.id, tag, { withCredentials: true })
-				.success(function (payload) {
-					deferred.resolve(payload);
-				})
-				.error(function () {
+				.then(function (response) {
+					deferred.resolve(response.data);
+				},
+				function () {
 					deferred.reject();
 				});
 
@@ -226,10 +226,10 @@ courseApp.factory("courseService", this.courseService = function ($http, $q, $wi
 			if (!course || !tag) { return; }
 
 			$http.delete(serverRoot + "/api/courseView/courses/" + course.id + "/tags/" + tag.id, { withCredentials: true })
-				.success(function (payload) {
-					deferred.resolve(payload);
-				})
-				.error(function () {
+				.then(function (response) {
+					deferred.resolve(response.data);
+				},
+				function () {
 					deferred.reject();
 				});
 
@@ -239,10 +239,10 @@ courseApp.factory("courseService", this.courseService = function ($http, $q, $wi
 			var deferred = $q.defer();
 
 			$http.get(serverRoot + "/api/courseView/sectionGroups/" + sectionGroupId + "/sections/", { withCredentials: true })
-				.success(function (payload) {
-					deferred.resolve(payload);
-				})
-				.error(function () {
+				.then(function (response) {
+					deferred.resolve(response.data);
+				},
+				function () {
 					deferred.reject();
 				});
 
@@ -253,10 +253,10 @@ courseApp.factory("courseService", this.courseService = function ($http, $q, $wi
 			if (!section) { return; }
 
 			$http.put(serverRoot + "/api/courseView/sections/" + section.id, section, { withCredentials: true })
-				.success(function (payload) {
-					deferred.resolve(payload);
-				})
-				.error(function () {
+				.then(function (response) {
+					deferred.resolve(response.data);
+				},
+				function () {
 					deferred.reject();
 				});
 
@@ -267,10 +267,10 @@ courseApp.factory("courseService", this.courseService = function ($http, $q, $wi
 			if (!section) { return; }
 
 			$http.post(serverRoot + "/api/courseView/sectionGroups/" + section.sectionGroupId + "/sections", section, { withCredentials: true })
-				.success(function (payload) {
-					deferred.resolve(payload);
-				})
-				.error(function () {
+				.then(function (response) {
+					deferred.resolve(response.data);
+				},
+				function () {
 					deferred.reject();
 				});
 
@@ -281,10 +281,10 @@ courseApp.factory("courseService", this.courseService = function ($http, $q, $wi
 			if (!section) { return; }
 
 			$http.delete(serverRoot + "/api/courseView/sections/" + section.id, { withCredentials: true })
-				.success(function (payload) {
-					deferred.resolve(payload);
-				})
-				.error(function () {
+				.then(function (response) {
+					deferred.resolve(response.data);
+				},
+				function () {
 					deferred.reject();
 				});
 
@@ -295,10 +295,10 @@ courseApp.factory("courseService", this.courseService = function ($http, $q, $wi
 			if (!course) { return; }
 
 			$http.get(dwUrl + "/census?subjectCode=" + course.subjectCode + "&courseNumber=" + course.courseNumber + "&token=" + dwToken)
-				.success(function (result) {
-					deferred.resolve(result);
-				})
-				.error(function () {
+				.then(function (response) {
+					deferred.resolve(response.data);
+				},
+				function () {
 					deferred.reject();
 				});
 
@@ -309,10 +309,10 @@ courseApp.factory("courseService", this.courseService = function ($http, $q, $wi
 			var privateParam = includePrivate ? "&private=true" : "";
 
 			$http.get(serverRoot + "/api/courseView/workgroups/" + workgroupId + "/years/" + year + "/queryCourses", includePrivate, { withCredentials: true })
-				.success(function (result) {
-					deferred.resolve(result);
-				})
-				.error(function () {
+				.then(function (response) {
+					deferred.resolve(response.data);
+				},
+				function () {
 					deferred.reject();
 				});
 

--- a/app/course/services/courseService.js
+++ b/app/course/services/courseService.js
@@ -6,79 +6,26 @@
  * Service in the courseApp.
  * courseApp specific api calls.
  */
-courseApp.factory("courseService", this.courseService = function ($http, $q, $window) {
+courseApp.factory("courseService", this.courseService = function (apiService) {
 	return {
 		getScheduleByWorkgroupIdAndYear: function (workgroupId, year, enableUnpublishedCourses) {
-			var deferred = $q.defer();
 			var showDoNotPrintParam = enableUnpublishedCourses ? "?showDoNotPrint=true" : "";
-
-			$http.get(serverRoot + "/api/courseView/workgroups/" + workgroupId + "/years/" + year + showDoNotPrintParam, { withCredentials: true })
-				.then(function (response) {
-					deferred.resolve(response.data);
-				},
-				function () {
-					deferred.reject();
-				});
-
-			return deferred.promise;
+			return apiService.get("/api/courseView/workgroups/" + workgroupId + "/years/" + year + showDoNotPrintParam);
 		},
 		downloadSchedule: function (workgroupId, year, enableUnpublishedCourses) {
-			var deferred = $q.defer();
 			var showDoNotPrintParam = enableUnpublishedCourses ? "?showDoNotPrint=true" : "";
-
-			$http.get(serverRoot + "/api/courseView/workgroups/" + workgroupId + "/years/" + year + "/generateExcel" + showDoNotPrintParam, { withCredentials: true })
-				.then(function (response) {
-					$window.location.href = response.data.redirect;
-					deferred.resolve(payload);
-				},
-				function () {
-					deferred.reject();
-				});
-
-			return deferred.promise;
+			return apiService.get("/api/courseView/workgroups/" + workgroupId + "/years/" + year + "/generateExcel" + showDoNotPrintParam);
 		},
 		addSectionGroup: function (sectionGroup) {
-			var deferred = $q.defer();
-
-			$http.post(serverRoot + "/api/courseView/sectionGroups/", sectionGroup, { withCredentials: true })
-				.then(function (response) {
-					deferred.resolve(response.data);
-				},
-				function () {
-					deferred.reject();
-				});
-
-			return deferred.promise;
+			return apiService.post("/api/courseView/sectionGroups/", sectionGroup);
 		},
 		updateSectionGroup: function (sectionGroup) {
-			var deferred = $q.defer();
-			if (!sectionGroup) { return; }
-
-			$http.put(serverRoot + "/api/courseView/sectionGroups/" + sectionGroup.id, sectionGroup, { withCredentials: true })
-				.then(function (response) {
-					deferred.resolve(response.data);
-				},
-				function () {
-					deferred.reject();
-				});
-
-			return deferred.promise;
+			return apiService.put("/api/courseView/sectionGroups/" + sectionGroup.id, sectionGroup);
 		},
 		removeSectionGroup: function (sectionGroupId) {
-			var deferred = $q.defer();
-
-			$http.delete(serverRoot + "/api/courseView/sectionGroups/" + sectionGroupId, { withCredentials: true })
-				.then(function (response) {
-					deferred.resolve(response.data);
-				},
-				function () {
-					deferred.reject();
-				});
-
-			return deferred.promise;
+			return apiService.delete("/api/courseView/sectionGroups/" + sectionGroupId);
 		},
 		createCourse: function (course, workgroupId, year) {
-			var deferred = $q.defer();
 			if (!course) { return; }
 
 			course.tags = [];
@@ -90,233 +37,73 @@ courseApp.factory("courseService", this.courseService = function ($http, $q, $wi
 				});
 			}
 
-			$http.post(serverRoot + "/api/courseView/workgroups/" + workgroupId + "/years/" + year + "/courses", course, { withCredentials: true })
-				.then(function (response) {
-					deferred.resolve(response.data);
-				},
-				function () {
-					deferred.reject();
-				});
-
-			return deferred.promise;
+			return apiService.post("/api/courseView/workgroups/" + workgroupId + "/years/" + year + "/courses", course);
 		},
 		importCoursesAndSectionGroups: function (sectionGroupImports, workgroupId, year, importTimes, importAssignments) {
-			var deferred = $q.defer();
-
-			$http.post(serverRoot + "/api/courseView/workgroups/" + workgroupId + "/years/" + year + "/sectionGroups?importTimes=" + importTimes + "&importAssignments=" + importAssignments, sectionGroupImports, { withCredentials: true })
-				.then(function (response) {
-					deferred.resolve(response.data);
-				},
-				function () {
-					deferred.reject();
-				});
-
-			return deferred.promise;
+			return apiService.post("/api/courseView/workgroups/" + workgroupId + "/years/" + year + "/sectionGroups?importTimes=" + importTimes + "&importAssignments=" + importAssignments, sectionGroupImports);
 		},
 		importCoursesAndSectionGroupsFromIPA: function (sectionGroupImports, workgroupId, year, importTimes, importAssignments) {
-			var deferred = $q.defer();
-
-			$http.post(serverRoot + "/api/courseView/workgroups/" + workgroupId + "/years/" + year + "/createCourses?importTimes=" + importTimes + "&importAssignments=" + importAssignments, sectionGroupImports, { withCredentials: true })
-				.then(function (response) {
-					deferred.resolve(response.data);
-				},
-				function () {
-					deferred.reject();
-				});
-
-			return deferred.promise;
+			return apiService.post("/api/courseView/workgroups/" + workgroupId + "/years/" + year + "/createCourses?importTimes=" + importTimes + "&importAssignments=" + importAssignments, sectionGroupImports);
 		},
 		updateCourse: function (course) {
-			var deferred = $q.defer();
 			if (!course) { return; }
 
-			$http.put(serverRoot + "/api/courseView/courses/" + course.id, course, { withCredentials: true })
-				.then(function (response) {
-					deferred.resolve(response.data);
-				},
-				function () {
-					deferred.reject();
-				});
-
-			return deferred.promise;
+			return apiService.put("/api/courseView/courses/" + course.id, course);
 		},
 		deleteCourse: function (course) {
-			var deferred = $q.defer();
-			if (!course) { return; }
-
-			$http.delete(serverRoot + "/api/courseView/courses/" + course.id, { withCredentials: true })
-				.then(function (response) {
-					deferred.resolve(response.data);
-				},
-				function () {
-					deferred.reject();
-				});
-
-			return deferred.promise;
+			return apiService.delete("/api/courseView/courses/" + course.id);
 		},
 		deleteMultipleCourses: function (courseIds, workgroupId, year) {
-			var deferred = $q.defer();
-
-			$http.put(serverRoot + "/api/courseView/schedules/" + workgroupId + "/" + year + "/courses", courseIds, { withCredentials: true })
-				.then(function (response) {
-					deferred.resolve(response.data);
-				},
-				function () {
-					deferred.reject();
-				});
-
-			return deferred.promise;
+			return apiService.put("/api/courseView/schedules/" + workgroupId + "/" + year + "/courses", courseIds);
 		},
 		submitMassAssignTags: function (massAssignTags, workgroupId, year) {
-			var deferred = $q.defer();
-
-			$http.put(serverRoot + "/api/courseView/workgroups/" + workgroupId + "/years/" + year + "/massAddTags", massAssignTags, { withCredentials: true })
-				.then(function (response) {
-					deferred.resolve(response.data);
-				},
-				function () {
-					deferred.reject();
-				});
-
-			return deferred.promise;
+			return apiService.put("/api/courseView/workgroups/" + workgroupId + "/years/" + year + "/massAddTags", massAssignTags);
 		},
 		searchCourses: function (query) {
-			var deferred = $q.defer();
-
-			$http.get(dwUrl + "/courses/search?q=" + query + "&token=" + dwToken)
-				.then(function (response) {
-					deferred.resolve(response.data);
-				},
-				function () {
-					deferred.reject();
-				});
-
-			return deferred.promise;
+			return apiService.get("/courses/search?q=" + query + "&token=" + dwToken, null, dwUrl);
 		},
 		searchImportCourses: function (subjectCode, year, includePrivate) {
-			var deferred = $q.defer();
 			var privateParam = includePrivate ? "&private=true" : "";
 
-			$http.get(dwUrl + "/sections/search?subjectCode=" + subjectCode + "&academicYear=" + year + "&token=" + dwToken + privateParam)
-				.then(function (response) {
-					deferred.resolve(response.data);
-				},
-				function () {
-					deferred.reject();
-				});
-
-			return deferred.promise;
+			return apiService.get("/sections/search?subjectCode=" + subjectCode + "&academicYear=" + year + "&token=" + dwToken + privateParam, null, dwUrl);
 		},
 		addTagToCourse: function (course, tag) {
-			var deferred = $q.defer();
 			if (!course) { return; }
 
-			$http.post(serverRoot + "/api/courseView/courses/" + course.id + "/tags/" + tag.id, tag, { withCredentials: true })
-				.then(function (response) {
-					deferred.resolve(response.data);
-				},
-				function () {
-					deferred.reject();
-				});
-
-			return deferred.promise;
+			return apiService.post("/api/courseView/courses/" + course.id + "/tags/" + tag.id, tag);
 		},
 		removeTagFromCourse: function (course, tag) {
-			var deferred = $q.defer();
 			if (!course || !tag) { return; }
 
-			$http.delete(serverRoot + "/api/courseView/courses/" + course.id + "/tags/" + tag.id, { withCredentials: true })
-				.then(function (response) {
-					deferred.resolve(response.data);
-				},
-				function () {
-					deferred.reject();
-				});
-
-			return deferred.promise;
+			return apiService.delete("/api/courseView/courses/" + course.id + "/tags/" + tag.id);
 		},
 		getSectionsBySectionGroupId: function (sectionGroupId) {
-			var deferred = $q.defer();
-
-			$http.get(serverRoot + "/api/courseView/sectionGroups/" + sectionGroupId + "/sections/", { withCredentials: true })
-				.then(function (response) {
-					deferred.resolve(response.data);
-				},
-				function () {
-					deferred.reject();
-				});
-
-			return deferred.promise;
+			return apiService.get("/api/courseView/sectionGroups/" + sectionGroupId + "/sections/");
 		},
 		updateSection: function (section) {
-			var deferred = $q.defer();
 			if (!section) { return; }
 
-			$http.put(serverRoot + "/api/courseView/sections/" + section.id, section, { withCredentials: true })
-				.then(function (response) {
-					deferred.resolve(response.data);
-				},
-				function () {
-					deferred.reject();
-				});
-
-			return deferred.promise;
+			return apiService.put("/api/courseView/sections/" + section.id, section);
 		},
 		createSection: function (section) {
-			var deferred = $q.defer();
 			if (!section) { return; }
 
-			$http.post(serverRoot + "/api/courseView/sectionGroups/" + section.sectionGroupId + "/sections", section, { withCredentials: true })
-				.then(function (response) {
-					deferred.resolve(response.data);
-				},
-				function () {
-					deferred.reject();
-				});
-
-			return deferred.promise;
+			return apiService.post("/api/courseView/sectionGroups/" + section.sectionGroupId + "/sections", section);
 		},
 		deleteSection: function (section) {
-			var deferred = $q.defer();
 			if (!section) { return; }
 
-			$http.delete(serverRoot + "/api/courseView/sections/" + section.id, { withCredentials: true })
-				.then(function (response) {
-					deferred.resolve(response.data);
-				},
-				function () {
-					deferred.reject();
-				});
-
-			return deferred.promise;
+			return apiService.delete("/api/courseView/sections/" + section.id);
 		},
 		getCourseCensus: function (course) {
-			var deferred = $q.defer();
 			if (!course) { return; }
 
-			$http.get(dwUrl + "/census?subjectCode=" + course.subjectCode + "&courseNumber=" + course.courseNumber + "&token=" + dwToken)
-				.then(function (response) {
-					deferred.resolve(response.data);
-				},
-				function () {
-					deferred.reject();
-				});
-
-			return deferred.promise;
+			return apiService.get("/census?subjectCode=" + course.subjectCode + "&courseNumber=" + course.courseNumber + "&token=" + dwToken, null, dwUrl);
 		},
 		searchCoursesFromIPA: function (workgroupId, year, includePrivate) {
-			var deferred = $q.defer();
 			var privateParam = includePrivate ? "&private=true" : "";
 
-			$http.get(serverRoot + "/api/courseView/workgroups/" + workgroupId + "/years/" + year + "/queryCourses", includePrivate, { withCredentials: true })
-				.then(function (response) {
-					deferred.resolve(response.data);
-				},
-				function () {
-					deferred.reject();
-				});
-
-			return deferred.promise;
+			return apiService.get("/api/courseView/workgroups/" + workgroupId + "/years/" + year + "/queryCourses", includePrivate);
 		}
 	};
 });

--- a/app/instructionalSupport/instructorSupportCallForm/services/instructionalSupportInstructorFormService.js
+++ b/app/instructionalSupport/instructorSupportCallForm/services/instructionalSupportInstructorFormService.js
@@ -1,69 +1,19 @@
-instructionalSupportApp.factory("instructionalSupportInstructorFormService", this.instructionalSupportInstructorFormService = function($http, $q, $window) {
+instructionalSupportApp.factory("instructionalSupportInstructorFormService", this.instructionalSupportInstructorFormService = function(apiService) {
 	return {
 		getInitialState: function(workgroupId, year, termShortCode) {
-			var deferred = $q.defer();
-
-			$http.get(serverRoot + "/api/instructionalSupportInstructorFormView/workgroups/" + workgroupId + "/years/" + year + "/termCode/" + termShortCode, { withCredentials: true })
-			.success(function(payload) {
-				deferred.resolve(payload);
-			})
-			.error(function() {
-				deferred.reject();
-			});
-
-			return deferred.promise;
+			return apiService.get("/api/instructionalSupportInstructorFormView/workgroups/" + workgroupId + "/years/" + year + "/termCode/" + termShortCode);
 		},
 		addInstructorPreference: function(sectionGroupId, supportStaffId) {
-			var deferred = $q.defer();
-
-			$http.post(serverRoot + "/api/instructionalSupportInstructorFormView/sectionGroups/" + sectionGroupId + "/supportStaff/" + supportStaffId, { withCredentials: true })
-			.success(function(payload) {
-				deferred.resolve(payload);
-			})
-			.error(function() {
-				deferred.reject();
-			});
-
-			return deferred.promise;
+			return apiService.post("/api/instructionalSupportInstructorFormView/sectionGroups/" + sectionGroupId + "/supportStaff/" + supportStaffId);
 		},
 		updateSupportCallResponse: function(supportCallResponse) {
-			var deferred = $q.defer();
-
-			$http.put(serverRoot + "/api/instructionalSupportInstructorFormView/instructorSupportCallResponses/" + supportCallResponse.id, supportCallResponse, { withCredentials: true })
-			.success(function(payload) {
-				deferred.resolve(payload);
-			})
-			.error(function() {
-				deferred.reject();
-			});
-
-			return deferred.promise;
+			return apiService.put("/api/instructionalSupportInstructorFormView/instructorSupportCallResponses/" + supportCallResponse.id, supportCallResponse);
 		},
 		updatePreferencesOrder: function(preferenceIds, scheduleId, sectionGroupId) {
-			var deferred = $q.defer();
-
-			$http.put(serverRoot + "/api/instructionalSupportInstructorFormView/schedules/" + scheduleId + "/sectionGroups/" + sectionGroupId, preferenceIds, { withCredentials: true })
-			.success(function(payload) {
-				deferred.resolve(payload);
-			})
-			.error(function() {
-				deferred.reject();
-			});
-
-			return deferred.promise;
+			return apiService.put("/api/instructionalSupportInstructorFormView/schedules/" + scheduleId + "/sectionGroups/" + sectionGroupId, preferenceIds);
 		},
 		deleteInstructorPreference: function(preferenceId) {
-			var deferred = $q.defer();
-
-			$http.delete(serverRoot + "/api/instructionalSupportInstructorFormView/instructorInstructionalSupportPreferences/" + preferenceId, { withCredentials: true })
-			.success(function(payload) {
-				deferred.resolve(payload);
-			})
-			.error(function() {
-				deferred.reject();
-			});
-
-			return deferred.promise;
+			return apiService.delete("/api/instructionalSupportInstructorFormView/instructorInstructionalSupportPreferences/" + preferenceId);
 		}
 	};
 });

--- a/app/instructionalSupport/studentSupportCallForm/services/studentService.js
+++ b/app/instructionalSupport/studentSupportCallForm/services/studentService.js
@@ -1,77 +1,22 @@
-instructionalSupportApp.factory("studentService", this.studentService = function($http, $q, $window) {
+instructionalSupportApp.factory("studentService", this.studentService = function(apiService) {
 	return {
 		getInitialState: function(workgroupId, year, termShortCode) {
-			var deferred = $q.defer();
-
-			$http.get(serverRoot + "/api/instructionalSupportStudentFormView/workgroups/" + workgroupId + "/years/" + year + "/termCode/" + termShortCode, { withCredentials: true })
-			.success(function(assignmentView) {
-				deferred.resolve(assignmentView);
-			})
-			.error(function() {
-				deferred.reject();
-			});
-
-			return deferred.promise;
+			return apiService.get("/api/instructionalSupportStudentFormView/workgroups/" + workgroupId + "/years/" + year + "/termCode/" + termShortCode);
 		},
 		addStudentPreference: function(sectionGroupId, type) {
-			var deferred = $q.defer();
-			$http.post(serverRoot + "/api/instructionalSupportStudentFormView/sectionGroups/" + sectionGroupId + "/preferenceType/" + type, { withCredentials: true })
-			.success(function(assignmentView) {
-				deferred.resolve(assignmentView);
-			})
-			.error(function() {
-				deferred.reject();
-			});
-
-			return deferred.promise;
+			return apiService.post("/api/instructionalSupportStudentFormView/sectionGroups/" + sectionGroupId + "/preferenceType/" + type);
 		},
 		updateSupportCallResponse: function(supportCallResponse) {
-			var deferred = $q.defer();
-			$http.put(serverRoot + "/api/instructionalSupportStudentFormView/studentSupportCallResponses/" + supportCallResponse.id, supportCallResponse, { withCredentials: true })
-			.success(function(assignmentView) {
-				deferred.resolve(assignmentView);
-			})
-			.error(function() {
-				deferred.reject();
-			});
-
-			return deferred.promise;
+			return apiService.put("/api/instructionalSupportStudentFormView/studentSupportCallResponses/" + supportCallResponse.id, supportCallResponse);
 		},
 		updatePreferencesOrder: function(preferenceIds, scheduleId, termCode) {
-			var deferred = $q.defer();
-			$http.put(serverRoot + "/api/instructionalSupportStudentFormView/schedules/" + scheduleId + "/terms/" + termCode, preferenceIds, { withCredentials: true })
-			.success(function(payload) {
-				deferred.resolve(payload);
-			})
-			.error(function() {
-				deferred.reject();
-			});
-
-			return deferred.promise;
+			return apiService.put("/api/instructionalSupportStudentFormView/schedules/" + scheduleId + "/terms/" + termCode, preferenceIds);
 		},
 		updatePreference: function(scheduleId, preference) {
-			var deferred = $q.defer();
-			$http.put(serverRoot + "/api/instructionalSupportStudentFormView/schedules/" + scheduleId + "/preferences/" + preference.id, preference, { withCredentials: true })
-			.success(function(payload) {
-				deferred.resolve(payload);
-			})
-			.error(function() {
-				deferred.reject();
-			});
-
-			return deferred.promise;
+			return apiService.put("/api/instructionalSupportStudentFormView/schedules/" + scheduleId + "/preferences/" + preference.id, preference);
 		},
 		deleteStudentPreference: function(preferenceId) {
-			var deferred = $q.defer();
-			$http.delete(serverRoot + "/api/instructionalSupportStudentFormView/studentInstructionalSupportPreferences/" + preferenceId, { withCredentials: true })
-			.success(function(payload) {
-				deferred.resolve(payload);
-			})
-			.error(function() {
-				deferred.reject();
-			});
-
-			return deferred.promise;
+			return apiService.delete("/api/instructionalSupportStudentFormView/studentInstructionalSupportPreferences/" + preferenceId);
 		}
 	};
 });

--- a/app/registrarReconciliationReport/services/reportService.js
+++ b/app/registrarReconciliationReport/services/reportService.js
@@ -6,163 +6,43 @@
  * Service in the reportApp.
  * reportApp specific api calls.
  */
-registrarReconciliationReportApp.factory("reportService", this.reportService = function ($http, $q, $window) {
+registrarReconciliationReportApp.factory("reportService", this.reportService = function ($http, $q, $window, apiService) {
 	return {
 		getSchedulesToCompare: function (workgroupId) {
-			var deferred = $q.defer();
-
-			$http.get(serverRoot + "/api/reportView/workgroups/" + workgroupId, { withCredentials: true })
-				.success(function (payload) {
-					deferred.resolve(payload);
-				})
-				.error(function () {
-					deferred.reject();
-				});
-
-			return deferred.promise;
+			return apiService.get("/api/reportView/workgroups/" + workgroupId);
 		},
 		getTermComparisonReport: function (workgroupId, year, termCode) {
-			var deferred = $q.defer();
-
-			$http.get(serverRoot + "/api/reportView/workgroups/" + workgroupId + "/years/" + year + "/termCode/" + termCode, { withCredentials: true })
-				.success(function (payload) {
-					deferred.resolve(payload);
-				})
-				.error(function () {
-					deferred.reject();
-				});
-
-			return deferred.promise;
+			return apiService.get("/api/reportView/workgroups/" + workgroupId + "/years/" + year + "/termCode/" + termCode);
 		},
 		updateSection: function (section) {
-			var deferred = $q.defer();
-
-			$http.put(serverRoot + "/api/reportView/sections/" + section.id, section, { withCredentials: true })
-				.success(function (payload) {
-					deferred.resolve(payload);
-				})
-				.error(function () {
-					deferred.reject();
-				});
-
-			return deferred.promise;
+			return apiService.put("/api/reportView/sections/" + section.id, section);
 		},
 		createSection: function (section) {
-			var deferred = $q.defer();
-
-			$http.post(serverRoot + "/api/reportView/sectionGroups/" + section.sectionGroupId + "/sections/" + section.sequenceNumber, section, { withCredentials: true })
-				.success(function (payload) {
-					deferred.resolve(payload);
-				})
-				.error(function () {
-					deferred.reject();
-				});
-
-			return deferred.promise;
+			return apiService.post("/api/reportView/sectionGroups/" + section.sectionGroupId + "/sections/" + section.sequenceNumber, section);
 		},
 		updateActivity: function (activity) {
-			var deferred = $q.defer();
-
-			$http.put(serverRoot + "/api/reportView/activities/" + activity.id, activity, { withCredentials: true })
-				.success(function (payload) {
-					deferred.resolve(payload);
-				})
-				.error(function () {
-					deferred.reject();
-				});
-
-			return deferred.promise;
+			return apiService.put("/api/reportView/activities/" + activity.id, activity);
 		},
 		deleteActivity: function (activity) {
-			var deferred = $q.defer();
-
-			$http.delete(serverRoot + "/api/reportView/activities/" + activity.id, { withCredentials: true })
-				.success(function (payload) {
-					deferred.resolve(payload);
-				})
-				.error(function () {
-					deferred.reject();
-				});
-
-			return deferred.promise;
+			return apiService.delete("/api/reportView/activities/" + activity.id);
 		},
 		createActivity: function (sectionId, activity) {
-			var deferred = $q.defer();
-
-			$http.post(serverRoot + "/api/reportView/sections/" + sectionId + "/activities/" + activity.typeCode, activity, { withCredentials: true })
-				.success(function (payload) {
-					deferred.resolve(payload);
-				})
-				.error(function () {
-					deferred.reject();
-				});
-
-			return deferred.promise;
+			return apiService.post("/api/reportView/sections/" + sectionId + "/activities/" + activity.typeCode, activity);
 		},
 		assignInstructor: function (sectionGroupId, instructor) {
-			var deferred = $q.defer();
-
-			$http.post(serverRoot + "/api/reportView/sectionGroups/" + sectionGroupId + "/instructors", instructor, { withCredentials: true })
-				.success(function (payload) {
-					deferred.resolve(payload);
-				})
-				.error(function () {
-					deferred.reject();
-				});
-
-			return deferred.promise;
+			return apiService.post("/api/reportView/sectionGroups/" + sectionGroupId + "/instructors", instructor);
 		},
 		unAssignInstructor: function (sectionGroupId, instructor) {
-			var deferred = $q.defer();
-
-			$http.delete(serverRoot + "/api/reportView/sectionGroups/" + sectionGroupId + "/instructors/" + instructor.loginId, { withCredentials: true })
-				.success(function (payload) {
-					deferred.resolve(payload);
-				})
-				.error(function () {
-					deferred.reject();
-				});
-
-			return deferred.promise;
+			return apiService.delete("/api/reportView/sectionGroups/" + sectionGroupId + "/instructors/" + instructor.loginId);
 		},
 		deleteSection: function (section) {
-			var deferred = $q.defer();
-
-			$http.delete(serverRoot + "/api/reportView/sections/" + section.id, { withCredentials: true })
-				.success(function (payload) {
-					deferred.resolve(payload);
-				})
-				.error(function () {
-					deferred.reject();
-				});
-
-			return deferred.promise;
+			return apiService.delete("/api/reportView/sections/" + section.id);
 		},
 		createSyncAction: function (syncAction) {
-			var deferred = $q.defer();
-
-			$http.post(serverRoot + "/api/reportView/syncActions", syncAction, { withCredentials: true })
-				.success(function (payload) {
-					deferred.resolve(payload);
-				})
-				.error(function () {
-					deferred.reject();
-				});
-
-			return deferred.promise;
+			return apiService.post("/api/reportView/syncActions", syncAction);
 		},
 		deleteSyncAction: function (syncActionId) {
-			var deferred = $q.defer();
-
-			$http.delete(serverRoot + "/api/reportView/syncActions/" + syncActionId, { withCredentials: true })
-				.success(function (payload) {
-					deferred.resolve(payload);
-				})
-				.error(function () {
-					deferred.reject();
-				});
-
-			return deferred.promise;
+			return apiService.delete("/api/reportView/syncActions/" + syncActionId);
 		}
 	};
 });

--- a/app/registrarReconciliationReport/services/reportService.js
+++ b/app/registrarReconciliationReport/services/reportService.js
@@ -6,7 +6,7 @@
  * Service in the reportApp.
  * reportApp specific api calls.
  */
-registrarReconciliationReportApp.factory("reportService", this.reportService = function ($http, $q, $window, apiService) {
+registrarReconciliationReportApp.factory("reportService", this.reportService = function (apiService) {
 	return {
 		getSchedulesToCompare: function (workgroupId) {
 			return apiService.get("/api/reportView/workgroups/" + workgroupId);

--- a/app/scheduleSummaryReport/services/scheduleSummaryService.js
+++ b/app/scheduleSummaryReport/services/scheduleSummaryService.js
@@ -6,34 +6,13 @@
  * Service in the reportApp.
  * reportApp specific api calls.
  */
-scheduleSummaryReportApp.factory("scheduleSummaryReportService", this.scheduleSummaryReportService = function ($http, $q, $window) {
+scheduleSummaryReportApp.factory("scheduleSummaryReportService", this.scheduleSummaryReportService = function (apiService) {
 	return {
 		getInitialState: function (workgroupId, year, termCode) {
-			var deferred = $q.defer();
-
-			$http.get(serverRoot + "/api/scheduleSummaryReportView/workgroups/" + workgroupId + "/years/" + year + "/terms/" + termCode, { withCredentials: true })
-				.success(function (payload) {
-					deferred.resolve(payload);
-				})
-				.error(function () {
-					deferred.reject();
-				});
-
-			return deferred.promise;
+			return apiService.get("/api/scheduleSummaryReportView/workgroups/" + workgroupId + "/years/" + year + "/terms/" + termCode);
 		},
 		downloadSchedule: function (workgroupId, year, shortTermCode) {
-			var deferred = $q.defer();
-
-			$http.get(serverRoot + "/api/scheduleSummaryReportView/workgroups/" + workgroupId + "/years/" + year + "/terms/" + shortTermCode + "/generateExcel", { withCredentials: true })
-				.success(function (payload) {
-					$window.location.href = payload.redirect;
-					deferred.resolve(payload);
-				})
-				.error(function () {
-					deferred.reject();
-				});
-
-			return deferred.promise;
+			return apiService.get("/api/scheduleSummaryReportView/workgroups/" + workgroupId + "/years/" + year + "/terms/" + shortTermCode + "/generateExcel");
 		}
 	};
 });

--- a/app/scheduling/services/schedulingService.js
+++ b/app/scheduling/services/schedulingService.js
@@ -6,126 +6,34 @@
  * Service in the schedulingApp.
  * schedulingApp specific api calls.
  */
-schedulingApp.factory("schedulingService", this.schedulingService = function ($http, $q) {
+schedulingApp.factory("schedulingService", this.schedulingService = function (apiService) {
 	return {
 		getScheduleByWorkgroupIdAndYearAndTermCode: function (workgroupId, year, termCode) {
-			var deferred = $q.defer();
-
-			$http.get(serverRoot + "/api/schedulingView/workgroups/" + workgroupId + "/years/" + year + "/termCode/" + termCode, { withCredentials: true })
-				.success(function (payload) {
-					deferred.resolve(payload);
-				})
-				.error(function () {
-					deferred.reject();
-				});
-
-			return deferred.promise;
+			return apiService.get("/api/schedulingView/workgroups/" + workgroupId + "/years/" + year + "/termCode/" + termCode);
 		},
 		updateActivity: function (activity) {
-			var deferred = $q.defer();
-
-			$http.put(serverRoot + "/api/schedulingView/activities/" + activity.id, activity, { withCredentials: true })
-				.success(function (payload) {
-					deferred.resolve(payload);
-				})
-				.error(function () {
-					deferred.reject();
-				});
-
-			return deferred.promise;
+			return apiService.put("/api/schedulingView/activities/" + activity.id, activity);
 		},
 		removeActivity: function (activityId) {
-			var deferred = $q.defer();
-
-			$http.delete(serverRoot + "/api/schedulingView/activities/" + activityId, { withCredentials: true })
-				.success(function (payload) {
-					deferred.resolve(payload);
-				})
-				.error(function () {
-					deferred.reject();
-				});
-
-			return deferred.promise;
+			return apiService.delete("/api/schedulingView/activities/" + activityId);
 		},
 		createSharedActivity: function (activityCode, sectionGroupId) {
-			var deferred = $q.defer();
-
-			$http.post(serverRoot + "/api/schedulingView/sectionGroups/" + sectionGroupId + "/activities/" + activityCode, { withCredentials: true })
-				.success(function (payload) {
-					deferred.resolve(payload);
-				})
-				.error(function () {
-					deferred.reject();
-				});
-
-			return deferred.promise;
+			return apiService.post("/api/schedulingView/sectionGroups/" + sectionGroupId + "/activities/" + activityCode);
 		},
 		createActivity: function (activityCode, sectionId) {
-			var deferred = $q.defer();
-
-			$http.post(serverRoot + "/api/schedulingView/sections/" + sectionId + "/activities/" + activityCode, { withCredentials: true })
-				.success(function (payload) {
-					deferred.resolve(payload);
-				})
-				.error(function () {
-					deferred.reject();
-				});
-
-			return deferred.promise;
+			return apiService.post("/api/schedulingView/sections/" + sectionId + "/activities/" + activityCode);
 		},
 		getActivities: function (section) {
-			var deferred = $q.defer();
-
-			$http.get(serverRoot + "/api/schedulingView/sections/" + section.id + "/activities", { withCredentials: true })
-				.success(function (payload) {
-					deferred.resolve(payload);
-				})
-				.error(function () {
-					deferred.reject();
-				});
-
-			return deferred.promise;
+			return apiService.get("/api/schedulingView/sections/" + section.id + "/activities");
 		},
 		getCourseActivityTypes: function (course) {
-			var deferred = $q.defer();
-
-			$http.get(dwUrl + "/activities?subjectCode=" + course.subjectCode + "&courseNumber=" + course.courseNumber + "&token=" + dwToken)
-				.success(function (result) {
-					deferred.resolve(result);
-				})
-				.error(function () {
-					deferred.reject();
-				});
-
-			return deferred.promise;
+			return apiService.get("/activities?subjectCode=" + course.subjectCode + "&courseNumber=" + course.courseNumber + "&token=" + dwToken, null, dwUrl);
 		},
 		createSection: function (section) {
-			var deferred = $q.defer();
-			if (!section) { return; }
-
-			$http.post(serverRoot + "/api/courseView/sectionGroups/" + section.sectionGroupId + "/sections", section, { withCredentials: true })
-				.success(function (payload) {
-					deferred.resolve(payload);
-				})
-				.error(function () {
-					deferred.reject();
-				});
-
-			return deferred.promise;
+			return apiService.post("/api/courseView/sectionGroups/" + section.sectionGroupId + "/sections", section);
 		},
 		deleteSection: function (section) {
-			var deferred = $q.defer();
-			if (!section) { return; }
-
-			$http.delete(serverRoot + "/api/courseView/sections/" + section.id, { withCredentials: true })
-				.success(function (payload) {
-					deferred.resolve(payload);
-				})
-				.error(function () {
-					deferred.reject();
-				});
-
-			return deferred.promise;
+			return apiService.delete("/api/courseView/sections/" + section.id);
 		}
 	};
 });

--- a/app/shared/services/apiService.js
+++ b/app/shared/services/apiService.js
@@ -53,10 +53,10 @@ angular.module('sharedApp')
 				var deferred = $q.defer();
 
 				$http(config)
-				.success(function(results) {
-					deferred.resolve(results);
-				})
-				.error(function() {
+				.then(function(response) {
+					deferred.resolve(response.data);
+				},
+				function() {
 					deferred.reject();
 				});
 

--- a/app/shared/services/dwService.js
+++ b/app/shared/services/dwService.js
@@ -6,7 +6,7 @@
  * Service in the ipaClientAngularApp.
  */
 angular.module('sharedApp')
-	.service('dwService', function ($http, $window, $q, $location, apiService) {
+	.service('dwService', function (apiService) {
 		return {
 			termCodeDescriptions: {
 				'05': 'Summer Session 1',
@@ -27,16 +27,7 @@ angular.module('sharedApp')
 			 * @returns {List[activity]}
 			 */
 			getDwActivitiesByCrn: function (crn, termCode) {
-				var deferred = $q.defer();
-				$http.get(dwUrl + "/sections/search/crn?termCode=" + termCode + "&crn=" + crn + "&token=" + dwToken)
-					.success(function (result) {
-						deferred.resolve(result);
-					})
-					.error(function () {
-						deferred.reject();
-					});
-
-				return deferred.promise;
+				return apiService.get("/sections/search/crn?termCode=" + termCode + "&crn=" + crn + "&token=" + dwToken, null, dwUrl);
 			},
 			/**
 			 * Provides a list of census snapshots based on the parameters given.

--- a/app/shared/sharedApp.js
+++ b/app/shared/sharedApp.js
@@ -112,7 +112,7 @@ sharedApp
 
 				switch (data.type) {
 					case "SUCCESS":
-						toastr.then(title, message, options);
+						toastr.success(title, message, options);
 						break;
 					case "ERROR":
 						options.timeOut = 0; // do not auto-hide error messages

--- a/app/shared/sharedApp.js
+++ b/app/shared/sharedApp.js
@@ -112,7 +112,7 @@ sharedApp
 
 				switch (data.type) {
 					case "SUCCESS":
-						toastr.success(title, message, options);
+						toastr.then(title, message, options);
 						break;
 					case "ERROR":
 						options.timeOut = 0; // do not auto-hide error messages

--- a/app/summary/services/summaryService.js
+++ b/app/summary/services/summaryService.js
@@ -6,20 +6,10 @@
  * Service in the workgroupApp.
  * workgroupApp specific api calls.
  */
-summaryApp.factory("summaryService", this.summaryService = function($http, $q) {
+summaryApp.factory("summaryService", this.summaryService = function(apiService) {
 	return {
 		getInitialState: function(workgroupId, year) {
-			var deferred = $q.defer();
-
-			$http.get(serverRoot + "/api/summaryView/" + workgroupId + "/" + year, { withCredentials: true })
-			.then(function(results) {
-				deferred.resolve(results.data);
-			},
-			function() {
-				deferred.reject();
-			});
-
-			return deferred.promise;
+			return apiService.get("/api/summaryView/" + workgroupId + "/" + year);
 		}
 	};
 });

--- a/app/summary/services/summaryService.js
+++ b/app/summary/services/summaryService.js
@@ -12,10 +12,10 @@ summaryApp.factory("summaryService", this.summaryService = function($http, $q) {
 			var deferred = $q.defer();
 
 			$http.get(serverRoot + "/api/summaryView/" + workgroupId + "/" + year, { withCredentials: true })
-			.success(function(summaryView) {
-				deferred.resolve(summaryView);
-			})
-			.error(function() {
+			.then(function(results) {
+				deferred.resolve(results.data);
+			},
+			function() {
 				deferred.reject();
 			});
 

--- a/app/supportAssignment/services/supportService.js
+++ b/app/supportAssignment/services/supportService.js
@@ -1,4 +1,4 @@
-supportAssignmentApp.factory("supportService", this.supportService = function($http, $q, $window) {
+supportAssignmentApp.factory("supportService", this.supportService = function(apiService) {
 	return {
 		getInitialState: function(workgroupId, year, termShortCode) {
 			return apiService.get("/api/instructionalSupportView/workgroups/" + workgroupId + "/years/" + year + "/termCode/" + termShortCode);

--- a/app/supportAssignment/services/supportService.js
+++ b/app/supportAssignment/services/supportService.js
@@ -1,103 +1,28 @@
 supportAssignmentApp.factory("supportService", this.supportService = function($http, $q, $window) {
 	return {
 		getInitialState: function(workgroupId, year, termShortCode) {
-			var deferred = $q.defer();
-
-			$http.get(serverRoot + "/api/instructionalSupportView/workgroups/" + workgroupId + "/years/" + year + "/termCode/" + termShortCode, { withCredentials: true })
-			.success(function(assignmentView) {
-				deferred.resolve(assignmentView);
-			})
-			.error(function() {
-				deferred.reject();
-			});
-
-			return deferred.promise;
+			return apiService.get("/api/instructionalSupportView/workgroups/" + workgroupId + "/years/" + year + "/termCode/" + termShortCode);
 		},
 		deleteAssignment: function(supportAssignment) {
-			var deferred = $q.defer();
-			$http.delete(serverRoot + "/api/instructionalSupportView/instructionalSupportAssignments/" + supportAssignment.id, { withCredentials: true })
-			.success(function(payload) {
-				deferred.resolve(payload);
-			})
-			.error(function() {
-				deferred.reject();
-			});
-
-			return deferred.promise;
+			return apiService.delete("/api/instructionalSupportView/instructionalSupportAssignments/" + supportAssignment.id);
 		},
 		assignStaffToSectionGroup: function(sectionGroupId, supportStaffId, type) {
-			var deferred = $q.defer();
-			$http.post(serverRoot + "/api/instructionalSupportView/sectionGroups/" + sectionGroupId + "/assignmentType/" + type + "/supportStaff/" + supportStaffId, { withCredentials: true })
-			.success(function(payload) {
-				deferred.resolve(payload);
-			})
-			.error(function() {
-				deferred.reject();
-			});
-
-			return deferred.promise;
+			return apiService.post("/api/instructionalSupportView/sectionGroups/" + sectionGroupId + "/assignmentType/" + type + "/supportStaff/" + supportStaffId);
 		},
 		assignStaffToSection: function(sectionId, supportStaffId, type) {
-			var deferred = $q.defer();
-			$http.post(serverRoot + "/api/instructionalSupportView/sections/" + sectionId + "/assignmentType/" + type + "/supportStaff/" + supportStaffId, { withCredentials: true })
-			.success(function(payload) {
-				deferred.resolve(payload);
-			})
-			.error(function() {
-				deferred.reject();
-			});
-
-			return deferred.promise;
+			return apiService.post("/api/instructionalSupportView/sections/" + sectionId + "/assignmentType/" + type + "/supportStaff/" + supportStaffId);
 		},
 		toggleSupportStaffSupportCallReview: function(scheduleId, termShortCode) {
-			var deferred = $q.defer();
-			$http.put(serverRoot + "/api/instructionalSupportView/schedules/" + scheduleId + "/terms/" + termShortCode + "/toggleSupportStaffSupportCallReview", { withCredentials: true })
-			.success(function(payload) {
-				deferred.resolve(payload);
-			})
-			.error(function() {
-				deferred.reject();
-			});
-
-			return deferred.promise;
+			return apiService.put("/api/instructionalSupportView/schedules/" + scheduleId + "/terms/" + termShortCode + "/toggleSupportStaffSupportCallReview");
 		},
 		toggleInstructorSupportCallReview: function(scheduleId, termShortCode) {
-			var deferred = $q.defer();
-			$http.put(serverRoot + "/api/instructionalSupportView/schedules/" + scheduleId + "/terms/" + termShortCode + "/toggleInstructorSupportCallReview", { withCredentials: true })
-			.success(function(payload) {
-				deferred.resolve(payload);
-			})
-			.error(function() {
-				deferred.reject();
-			});
-
-			return deferred.promise;
+			return apiService.put("/api/instructionalSupportView/schedules/" + scheduleId + "/terms/" + termShortCode + "/toggleInstructorSupportCallReview");
 		},
 		updateSupportAppointment: function (supportAppointment) {
-			var deferred = $q.defer();
-			$http.put(serverRoot + "/api/instructionalSupportView/schedules/" + supportAppointment.scheduleId, supportAppointment, { withCredentials: true })
-				.success(function (payload) {
-					deferred.resolve(payload);
-				})
-				.error(function () {
-					deferred.reject();
-				});
-
-			return deferred.promise;
+			return apiService.put("/api/instructionalSupportView/schedules/" + supportAppointment.scheduleId, supportAppointment);
 		},
 		updateSectionGroup: function (sectionGroup) {
-			var deferred = $q.defer();
-			if (!sectionGroup) { return; }
-
-			$http.put(serverRoot + "/api/courseView/sectionGroups/" + sectionGroup.id, sectionGroup, { withCredentials: true })
-				.success(function (payload) {
-					deferred.resolve(payload);
-				})
-				.error(function () {
-					deferred.reject();
-				});
-
-			return deferred.promise;
+			return apiService.put("/api/courseView/sectionGroups/" + sectionGroup.id, sectionGroup);
 		}
 	};
 });

--- a/app/supportCall/controllers/InstructionalSupportCallStatusCtrl.js
+++ b/app/supportCall/controllers/InstructionalSupportCallStatusCtrl.js
@@ -6,183 +6,197 @@
  * Controller of the ipaClientAngularApp
  */
 supportCallApp.controller('InstructionalSupportCallStatusCtrl', ['$scope', '$rootScope', '$window', '$location', '$routeParams', '$uibModal', 'instructionalSupportCallStatusActionCreators',
-		this.InstructionalSupportCallStatusCtrl = function ($scope, $rootScope, $window, $location, $routeParams, $uibModal, instructionalSupportCallStatusActionCreators) {
-			$window.document.title = "Instructional Support";
-			$scope.workgroupId = $routeParams.workgroupId;
-			$scope.year = $routeParams.year;
-			$scope.nextYear = (parseInt($scope.year) + 1).toString().slice(-2);
-			$scope.termShortCode = $routeParams.termShortCode;
+	this.InstructionalSupportCallStatusCtrl = function ($scope, $rootScope, $window, $location, $routeParams, $uibModal, instructionalSupportCallStatusActionCreators) {
+		$window.document.title = "Instructional Support";
+		$scope.workgroupId = $routeParams.workgroupId;
+		$scope.year = $routeParams.year;
+		$scope.nextYear = (parseInt($scope.year) + 1).toString().slice(-2);
+		$scope.termShortCode = $routeParams.termShortCode;
 
-			$scope.instructorsSelected = false;
-			$scope.supportStaffSelected = false;
+		$scope.instructorsSelected = false;
+		$scope.supportStaffSelected = false;
 
-			// Generate termCode
-			if ($scope.termShortCode < 4) {
-				$scope.termCode = (parseInt($scope.year) + 1) + $scope.termShortCode;
+		// Generate termCode
+		if ($scope.termShortCode < 4) {
+			$scope.termCode = (parseInt($scope.year) + 1) + $scope.termShortCode;
+		} else {
+			$scope.termCode = $scope.year + $scope.termShortCode;
+		}
+
+		$scope.view = {};
+
+		$rootScope.$on('supportCallStatusStateChanged', function (event, data) {
+			$scope.view.state = data;
+		});
+
+		$scope.removeInstructor = function(instructor) {
+			instructionalSupportCallStatusActionCreators.removeInstructorFromSupportCall(instructor, $scope.view.state.misc.scheduleId, $scope.termCode);
+		};
+
+		$scope.removeSupportStaff = function(supportStaff) {
+			instructionalSupportCallStatusActionCreators.removeSupportStaffFromSupportCall(supportStaff, $scope.view.state.misc.scheduleId, $scope.termCode);
+		};
+
+		$scope.numberToFloor = function(number) {
+			return Math.floor(number);
+		};
+
+		$scope.openAddInstructorsModal = function() {
+			$scope.openAddParticipantsSupportCall("instructor");
+		};
+
+		$scope.openAddSupportStaffModal = function () {
+			$scope.openAddParticipantsSupportCall("supportStaff");
+		};
+
+		$scope.toggleParticipantSelection = function(participant) {
+			if (participant.selected) {
+				participant.selected = false;
 			} else {
-				$scope.termCode = $scope.year + $scope.termShortCode;
+				participant.selected = true;
+			}
+		};
+
+		$scope.toggleInstructorsSelection = function() {
+			$scope.instructorsSelected = !$scope.instructorsSelected;
+
+			$scope.view.state.supportCall.instructors.forEach(function(instructor) {
+				instructor.selected = $scope.instructorsSelected;
+			});
+		};
+
+		$scope.toggleSupportStaffSelection = function() {
+			$scope.supportStaffSelected = !$scope.supportStaffSelected;
+
+			$scope.view.state.supportCall.supportStaff.forEach(function(slotSupportStaff) {
+				slotSupportStaff.selected = $scope.supportStaffSelected;
+			});
+		};
+
+		$scope.atLeastOneInstructorSelected = function() {
+			var instructorIsSelected = false;
+
+			if ($scope.view.state) {
+				$scope.view.state.supportCall.instructors.forEach(function(instructor) {
+					if (instructor.selected) {
+						instructorIsSelected = true;
+					}
+				});
 			}
 
-			$scope.view = {};
+			return instructorIsSelected;
+		};
 
-			$rootScope.$on('supportCallStatusStateChanged', function (event, data) {
-				$scope.view.state = data;
+		$scope.atLeastOneStudentSelected = function() {
+			var instructorIsSelected = false;
+
+			if ($scope.view.state) {
+				$scope.view.state.supportCall.supportStaff.forEach(function(participant) {
+					if (participant.selected) {
+						instructorIsSelected = true;
+					}
+				});
+			}
+
+			return instructorIsSelected;
+		};
+
+		$scope.openAddParticipantsSupportCall = function(supportCallMode) {
+			modalInstance = $uibModal.open({
+				templateUrl: 'AddSupportCallModal.html',
+				controller: ModalAddSupportCallCtrl,
+				size: 'lg',
+				resolve: {
+					supportCallMode: function () {
+						return supportCallMode;
+					},
+					scheduleId: function () {
+						return $scope.view.state.misc.scheduleId;
+					},
+					state: function () {
+						return $scope.view.state;
+					},
+					year: function () {
+						return $scope.year;
+					},
+					nextYear: function () {
+						return $scope.nextYear;
+					},
+					termShortCode: function () {
+						return $scope.termShortCode;
+					}
+				}
 			});
 
-			$scope.removeInstructor = function(instructor) {
-				instructionalSupportCallStatusActionCreators.removeInstructorFromSupportCall(instructor, $scope.view.state.misc.scheduleId, $scope.termCode);
-			};
+			modalInstance.result.then(function () {
+				// This modal does not 'submit' in a traditional sense.
+			},
+			function () {
+				// Modal closed
+			});
+		};
 
-			$scope.removeSupportStaff = function(supportStaff) {
-				instructionalSupportCallStatusActionCreators.removeSupportStaffFromSupportCall(supportStaff, $scope.view.state.misc.scheduleId, $scope.termCode);
-			};
+		$scope.openContactStudentsModal = function() {
+			$scope.openContactParticipantModal("supportStaff");
+		};
 
-			$scope.numberToFloor = function(number) {
-				return Math.floor(number);
-			};
+		$scope.openContactInstructorsModal = function() {
+			$scope.openContactParticipantModal("instructor");
+		};
 
-			$scope.openAddInstructorsModal = function() {
-				$scope.openAddParticipantsSupportCall("instructor");
-			};
+		// Launches Contact Modal
+		$scope.openContactParticipantModal = function(supportCallMode) {
+			selectedParticipants = [];
 
-			$scope.openAddSupportStaffModal = function () {
-				$scope.openAddParticipantsSupportCall("supportStaff");
-			};
-
-			$scope.toggleParticipantSelection = function(participant) {
-				if (participant.selected) {
-					participant.selected = false;
-				} else {
-					participant.selected = true;
-				}
-			};
-
-			$scope.toggleInstructorsSelection = function() {
-				$scope.instructorsSelected = !$scope.instructorsSelected;
-
+			if (supportCallMode == "instructor") {
 				$scope.view.state.supportCall.instructors.forEach(function(instructor) {
-					instructor.selected = $scope.instructorsSelected;
+					if (instructor.selected) {
+						selectedParticipants.push(instructor);
+					}
 				});
-			};
-
-			$scope.toggleSupportStaffSelection = function() {
-				$scope.supportStaffSelected = !$scope.supportStaffSelected;
-
+			}
+			if (supportCallMode == "supportStaff") {
 				$scope.view.state.supportCall.supportStaff.forEach(function(slotSupportStaff) {
-					slotSupportStaff.selected = $scope.supportStaffSelected;
-				});
-			};
-
-			$scope.atLeastOneInstructorSelected = function() {
-				var instructorIsSelected = false;
-
-				if ($scope.view.state) {
-					$scope.view.state.supportCall.instructors.forEach(function(instructor) {
-						if (instructor.selected) {
-							instructorIsSelected = true;
-						}
-					});
-				}
-
-				return instructorIsSelected;
-			};
-
-			$scope.atLeastOneStudentSelected = function() {
-				var instructorIsSelected = false;
-
-				if ($scope.view.state) {
-					$scope.view.state.supportCall.supportStaff.forEach(function(participant) {
-						if (participant.selected) {
-							instructorIsSelected = true;
-						}
-					});
-				}
-
-				return instructorIsSelected;
-			};
-
-			$scope.openAddParticipantsSupportCall = function(supportCallMode) {
-				modalInstance = $uibModal.open({
-					templateUrl: 'AddSupportCallModal.html',
-					controller: ModalAddSupportCallCtrl,
-					size: 'lg',
-					resolve: {
-						supportCallMode: function () {
-							return supportCallMode;
-						},
-						scheduleId: function () {
-							return $scope.view.state.misc.scheduleId;
-						},
-						state: function () {
-							return $scope.view.state;
-						},
-						year: function () {
-							return $scope.year;
-						},
-						nextYear: function () {
-							return $scope.nextYear;
-						},
-						termShortCode: function () {
-							return $scope.termShortCode;
-						}
+					if (slotSupportStaff.selected) {
+						selectedParticipants.push(slotSupportStaff);
 					}
 				});
-			};
+			}
 
-			$scope.openContactStudentsModal = function() {
-				$scope.openContactParticipantModal("supportStaff");
-			};
-
-			$scope.openContactInstructorsModal = function() {
-				$scope.openContactParticipantModal("instructor");
-			};
-
-			// Launches Contact Modal
-			$scope.openContactParticipantModal = function(supportCallMode) {
-				selectedParticipants = [];
-
-				if (supportCallMode == "instructor") {
-					$scope.view.state.supportCall.instructors.forEach(function(instructor) {
-						if (instructor.selected) {
-							selectedParticipants.push(instructor);
-						}
-					});
-				}
-				if (supportCallMode == "supportStaff") {
-					$scope.view.state.supportCall.supportStaff.forEach(function(slotSupportStaff) {
-						if (slotSupportStaff.selected) {
-							selectedParticipants.push(slotSupportStaff);
-						}
-					});
-				}
-
-				modalInstance = $uibModal.open({
-					templateUrl: 'ContactSupportCallModal.html',
-					controller: ModalContactSupportCallCtrl,
-					size: 'lg',
-					resolve: {
-						supportCallMode: function () {
-							return supportCallMode;
-						},
-						scheduleId: function () {
-							return $scope.view.state.misc.scheduleId;
-						},
-						state: function () {
-							return $scope.view.state;
-						},
-						year: function () {
-							return $scope.year;
-						},
-						termShortCode: function () {
-							return $scope.termShortCode;
-						},
-						selectedParticipants: function () {
-							return selectedParticipants;
-						}
+			modalInstance = $uibModal.open({
+				templateUrl: 'ContactSupportCallModal.html',
+				controller: ModalContactSupportCallCtrl,
+				size: 'lg',
+				resolve: {
+					supportCallMode: function () {
+						return supportCallMode;
+					},
+					scheduleId: function () {
+						return $scope.view.state.misc.scheduleId;
+					},
+					state: function () {
+						return $scope.view.state;
+					},
+					year: function () {
+						return $scope.year;
+					},
+					termShortCode: function () {
+						return $scope.termShortCode;
+					},
+					selectedParticipants: function () {
+						return selectedParticipants;
 					}
-				});
-			};
-	}]);
+				}
+			});
+
+			modalInstance.result.then(function () {
+				// This modal does not 'submit' in a traditional sense.
+			},
+			function () {
+				// Modal closed
+			});
+		};
+}]);
 
 InstructionalSupportCallStatusCtrl.getPayload = function (authService, instructionalSupportCallStatusActionCreators, $route) {
 	authService.validate(localStorage.getItem('JWT'), $route.current.params.workgroupId, $route.current.params.year).then(function () {

--- a/app/supportCall/services/instructionalSupportCallStatusService.js
+++ b/app/supportCall/services/instructionalSupportCallStatusService.js
@@ -1,91 +1,25 @@
-supportCallApp.factory("instructionalSupportCallStatusService", this.instructionalSupportAssignmentService = function($http, $q, $window) {
+supportCallApp.factory("instructionalSupportCallStatusService", this.instructionalSupportAssignmentService = function(apiService) {
 	return {
 		getInitialState: function(workgroupId, year, termShortCode) {
-			var deferred = $q.defer();
-
-			$http.get(serverRoot + "/api/instructionalSupportView/workgroups/" + workgroupId + "/years/" + year +"/" + termShortCode + "/supportCallStatus", { withCredentials: true })
-			.success(function(payload) {
-				deferred.resolve(payload);
-			})
-			.error(function() {
-				deferred.reject();
-			});
-
-			return deferred.promise;
+			return apiService.get("/api/instructionalSupportView/workgroups/" + workgroupId + "/years/" + year +"/" + termShortCode + "/supportCallStatus");
 		},
 		addStudentsSupportCall: function(scheduleId, studentSupportCall) {
-			var deferred = $q.defer();
-			$http.post(serverRoot + "/api/supportCallView/" + scheduleId + "/addStudents", studentSupportCall, { withCredentials: true })
-			.success(function(payload) {
-				deferred.resolve(payload);
-			})
-			.error(function() {
-				deferred.reject();
-			});
-
-			return deferred.promise;
+			return apiService.post("/api/supportCallView/" + scheduleId + "/addStudents", studentSupportCall);
 		},
 		addInstructorsSupportCall: function(scheduleId, instructorSupportCall) {
-			var deferred = $q.defer();
-			$http.post(serverRoot + "/api/supportCallView/" + scheduleId + "/addInstructors", instructorSupportCall, { withCredentials: true })
-			.success(function(payload) {
-				deferred.resolve(payload);
-			})
-			.error(function() {
-				deferred.reject();
-			});
-
-			return deferred.promise;
+			return apiService.post("/api/supportCallView/" + scheduleId + "/addInstructors", instructorSupportCall);
 		},
 		contactInstructorsSupportCall: function(scheduleId, supportCallData) {
-			var deferred = $q.defer();
-			$http.put(serverRoot + "/api/supportCallView/" + scheduleId + "/contactInstructors", supportCallData, { withCredentials: true })
-			.success(function(payload) {
-				deferred.resolve(payload);
-			})
-			.error(function() {
-				deferred.reject();
-			});
-
-			return deferred.promise;
+			return apiService.put("/api/supportCallView/" + scheduleId + "/contactInstructors", supportCallData);
 		},
 		contactSupportStaffSupportCall: function(scheduleId, supportCallData) {
-			var deferred = $q.defer();
-			$http.put(serverRoot + "/api/supportCallView/" + scheduleId + "/contactSupportStaff", supportCallData, { withCredentials: true })
-			.success(function(payload) {
-				deferred.resolve(payload);
-			})
-			.error(function() {
-				deferred.reject();
-			});
-
-			return deferred.promise;
+			return apiService.put("/api/supportCallView/" + scheduleId + "/contactSupportStaff", supportCallData);
 		},
 		removeInstructorFromSupportCall: function(instructor, scheduleId, termCode) {
-			var deferred = $q.defer();
-
-			$http.delete(serverRoot + "/api/supportCallView/schedules/" + scheduleId + "/instructorSupportCallResponses/" + instructor.supportCallResponseId, { withCredentials: true })
-			.success(function(payload) {
-				deferred.resolve(payload);
-			})
-			.error(function() {
-				deferred.reject();
-			});
-
-			return deferred.promise;
+			return apiService.delete("/api/supportCallView/schedules/" + scheduleId + "/instructorSupportCallResponses/" + instructor.supportCallResponseId);
 		},
 		removeStudentFromSupportCall: function(student, scheduleId, termCode) {
-			var deferred = $q.defer();
-
-			$http.delete(serverRoot + "/api/supportCallView/schedules/" + scheduleId + "/studentSupportCallResponses/" + student.supportCallResponseId, { withCredentials: true })
-			.success(function(payload) {
-				deferred.resolve(payload);
-			})
-			.error(function() {
-				deferred.reject();
-			});
-
-			return deferred.promise;
+			return apiService.delete("/api/supportCallView/schedules/" + scheduleId + "/studentSupportCallResponses/" + student.supportCallResponseId);
 		}
 	};
 });

--- a/app/teachingCall/teachingCallForm/services/teachingCallFormService.js
+++ b/app/teachingCall/teachingCallForm/services/teachingCallFormService.js
@@ -1,95 +1,25 @@
-teachingCallApp.factory("teachingCallFormService", this.teachingCallFormService = function($http, $q, $window) {
+teachingCallApp.factory("teachingCallFormService", this.teachingCallFormService = function(apiService) {
 	return {
 		getInitialState: function(workgroupId, year) {
-			var deferred = $q.defer();
-
-			$http.get(serverRoot + "/api/teachingCallView/" + workgroupId + "/" + year + "/teachingCallForm", { withCredentials: true })
-			.success(function(assignmentView) {
-				deferred.resolve(assignmentView);
-			})
-			.error(function() {
-				deferred.reject();
-			});
-
-			return deferred.promise;
+			return apiService.get("/api/teachingCallView/" + workgroupId + "/" + year + "/teachingCallForm");
 		},
 		addPreference: function (teachingAssignment) {
-			var deferred = $q.defer();
-
-			$http.post(serverRoot + "/api/assignmentView/preferences/" + teachingAssignment.scheduleId, teachingAssignment, { withCredentials: true })
-			.success(function(payload) {
-				deferred.resolve(payload);
-			})
-			.error(function() {
-				deferred.reject();
-			});
-
-			return deferred.promise;
+			return apiService.post("/api/assignmentView/preferences/" + teachingAssignment.scheduleId, teachingAssignment);
 		},
 		removePreference: function (teachingAssignment) {
-			var deferred = $q.defer();
-
-			$http.delete(serverRoot + "/api/assignmentView/preferences/" + teachingAssignment.id, { withCredentials: true })
-			.success(function(payload) {
-				deferred.resolve(payload);
-			})
-			.error(function() {
-				deferred.reject();
-			});
-
-			return deferred.promise;
+			return apiService.delete("/api/assignmentView/preferences/" + teachingAssignment.id);
 		},
 		updateAssignmentsOrder: function (sortedTeachingAssignmentIds, scheduleId) {
-			var deferred = $q.defer();
-
-			$http.put(serverRoot + "/api/assignmentView/schedules/" + scheduleId + "/teachingAssignments" , sortedTeachingAssignmentIds, { withCredentials: true })
-			.success(function(payload) {
-				deferred.resolve(payload);
-			})
-			.error(function() {
-				deferred.reject();
-			});
-
-			return deferred.promise;
+			return apiService.put("/api/assignmentView/schedules/" + scheduleId + "/teachingAssignments" , sortedTeachingAssignmentIds);
 		},
 		updateTeachingCallResponse: function (teachingCallResponse) {
-			var deferred = $q.defer();
-
-			$http.put(serverRoot + "/api/assignmentView/teachingCallResponses/" + teachingCallResponse.id, teachingCallResponse, { withCredentials: true })
-			.success(function(payload) {
-				deferred.resolve(payload);
-			})
-			.error(function() {
-				deferred.reject();
-			});
-
-			return deferred.promise;
+			return apiService.put("/api/assignmentView/teachingCallResponses/" + teachingCallResponse.id, teachingCallResponse);
 		},
 		createAvailability: function (teachingCallResponse) {
-			var deferred = $q.defer();
-
-			$http.post(serverRoot + "/api/assignmentView/teachingCallResponses/" + teachingCallResponse.scheduleId  + "/" + teachingCallResponse.instructorId, teachingCallResponse, { withCredentials: true })
-			.success(function(payload) {
-				deferred.resolve(payload);
-			})
-			.error(function() {
-				deferred.reject();
-			});
-
-			return deferred.promise;
+			return apiService.post("/api/assignmentView/teachingCallResponses/" + teachingCallResponse.scheduleId  + "/" + teachingCallResponse.instructorId, teachingCallResponse);
 		},
 		updateTeachingCallReceipt: function (teachingCallReceipt) {
-			var deferred = $q.defer();
-
-			$http.put(serverRoot + "/api/assignmentView/teachingCallReceipts/" + teachingCallReceipt.id, teachingCallReceipt, { withCredentials: true })
-			.success(function(payload) {
-				deferred.resolve(payload);
-			})
-			.error(function() {
-				deferred.reject();
-			});
-
-			return deferred.promise;
+			return apiService.put("/api/assignmentView/teachingCallReceipts/" + teachingCallReceipt.id, teachingCallReceipt);
 		},
 		allTerms: function () {
 			var allTerms = {

--- a/app/teachingCall/teachingCallStatus/controllers/TeachingCallStatusCtrl.js
+++ b/app/teachingCall/teachingCallStatus/controllers/TeachingCallStatusCtrl.js
@@ -66,6 +66,9 @@ teachingCallApp.controller('TeachingCallStatusCtrl', ['$scope', '$rootScope', '$
 
 				modalInstance.result.then(function (teachingCallConfig) {
 					$scope.contactInstructors($scope.workgroupId, $scope.year, teachingCallConfig);
+				},
+				function () {
+					// Modal closed
 				});
 			};
 
@@ -109,6 +112,9 @@ teachingCallApp.controller('TeachingCallStatusCtrl', ['$scope', '$rootScope', '$
 
 				modalInstance.result.then(function (teachingCallConfig) {
 					$scope.addInstructorsToTeachingCall($scope.workgroupId, $scope.year, teachingCallConfig);
+				},
+				function () {
+					// Modal closed
 				});
 			};
 

--- a/app/teachingCall/teachingCallStatus/services/teachingCallStatusService.js
+++ b/app/teachingCall/teachingCallStatus/services/teachingCallStatusService.js
@@ -1,57 +1,19 @@
-teachingCallApp.factory("teachingCallStatusService", this.teachingCallStatusService = function($http, $q, $window) {
+teachingCallApp.factory("teachingCallStatusService", this.teachingCallStatusService = function(apiService) {
 	return {
 		getInitialState: function(workgroupId, year) {
-			var deferred = $q.defer();
-
-			$http.get(serverRoot + "/api/teachingCallView/" + workgroupId + "/" + year + "/teachingCallStatus", { withCredentials: true })
-			.success(function(assignmentView) {
-				deferred.resolve(assignmentView);
-			})
-			.error(function() {
-				deferred.reject();
-			});
-
-			return deferred.promise;
+			return apiService.get("/api/teachingCallView/" + workgroupId + "/" + year + "/teachingCallStatus");
 		},
 		addInstructorsToTeachingCall: function (workgroupId, year, teachingCallConfig) {
-			var deferred = $q.defer();
-
-			$http.post(serverRoot + "/api/teachingCallView/" + workgroupId + "/" + year + "/addInstructors", teachingCallConfig, { withCredentials: true })
-			.success(function(payload) {
-				deferred.resolve(payload);
-			})
-			.error(function() {
-				deferred.reject();
-			});
-
-			return deferred.promise;
+			return apiService.post("/api/teachingCallView/" + workgroupId + "/" + year + "/addInstructors", teachingCallConfig);
 		},
 		contactInstructors: function (workgroupId, year, receiptsPayload) {
 			payload = {};
 			payload.receipts = receiptsPayload;
-			var deferred = $q.defer();
-			$http.put(serverRoot + "/api/teachingCallView/" + workgroupId + "/" + year + "/contactInstructors", payload, { withCredentials: true })
-			.success(function(payload) {
-				deferred.resolve(payload);
-			})
-			.error(function() {
-				deferred.reject();
-			});
 
-			return deferred.promise;
+			return apiService.put("/api/teachingCallView/" + workgroupId + "/" + year + "/contactInstructors", payload);
 		},
 		removeInstructorFromTeachingCall: function (teachingCallReceiptId) {
-			var deferred = $q.defer();
-
-			$http.delete(serverRoot + "/api/teachingCallView/teachingCallReceipts/" + teachingCallReceiptId, { withCredentials: true })
-			.success(function(payload) {
-				deferred.resolve(payload);
-			})
-			.error(function() {
-				deferred.reject();
-			});
-
-			return deferred.promise;
+			return apiService.delete("/api/teachingCallView/teachingCallReceipts/" + teachingCallReceiptId);
 		}
 	};
 });

--- a/app/teachingCallResponseReport/services/teachingCallResponseReportService.js
+++ b/app/teachingCallResponseReport/services/teachingCallResponseReportService.js
@@ -6,30 +6,18 @@
  * Service in the teachingCallResponseReportApp.
  * teachingCallResponseReportApp specific api calls.
  */
-teachingCallResponseReportApp.factory("teachingCallResponseReportService", this.teachingCallResponseReportService = function ($http, $q, $window) {
+teachingCallResponseReportApp.factory("teachingCallResponseReportService", this.teachingCallResponseReportService = function ($http, $q, $window, apiService) {
 	return {
 		getInitialState: function (workgroupId, year) {
-			var deferred = $q.defer();
-
-			$http.get(serverRoot + "/api/teachingCallResponseReportView/workgroups/" + workgroupId + "/years/" + year, { withCredentials: true })
-				.success(function (payload) {
-					deferred.resolve(payload);
-				})
-				.error(function () {
-					deferred.reject();
-				});
-
-			return deferred.promise;
+			return apiService.get("/api/teachingCallResponseReportView/workgroups/" + workgroupId + "/years/" + year);
 		},
 		download: function (workgroupId, year) {
-			var deferred = $q.defer();
-
 			$http.get(serverRoot + "/api/teachingCallResponseReportView/workgroups/" + workgroupId + "/years/" + year + "/generateExcel", { withCredentials: true })
-			.success(function(payload) {
+			.then(function(payload) {
 				$window.location.href = payload.redirect;
 				deferred.resolve(payload);
-			})
-			.error(function() {
+			},
+			function() {
 				deferred.reject();
 			});
 

--- a/app/workgroup/services/workgroupService.js
+++ b/app/workgroup/services/workgroupService.js
@@ -6,189 +6,49 @@
  * Service in the workgroupApp.
  * workgroupApp specific api calls.
  */
-workgroupApp.factory("workgroupService", this.workgroupService = function($http, $q) {
+workgroupApp.factory("workgroupService", this.workgroupService = function(apiService) {
 	return {
 		getWorkgroupByCode: function(workgroupId) {
-			var deferred = $q.defer();
-
-			$http.get(serverRoot + "/api/workgroupView/" + workgroupId, { withCredentials: true })
-			.success(function(workgroup) {
-				deferred.resolve(workgroup);
-			})
-			.error(function() {
-				deferred.reject();
-			});
-
-			return deferred.promise;
+			return apiService.get("/api/workgroupView/" + workgroupId);
 		},
 		addTag: function (workgroupId, tag) {
-			var deferred = $q.defer();
-
-			$http.post(serverRoot + "/api/workgroupView/" + workgroupId + "/tags", tag, { withCredentials: true })
-			.success(function(tag) {
-				deferred.resolve(tag);
-			})
-			.error(function() {
-				deferred.reject();
-			});
-
-			return deferred.promise;
+			return apiService.post("/api/workgroupView/" + workgroupId + "/tags", tag);
 		},
 		updateTag: function (workgroupId, tag) {
-			var deferred = $q.defer();
-
-			$http.put(serverRoot + "/api/workgroupView/" + workgroupId + "/tags/" + tag.id, tag, { withCredentials: true })
-			.success(function(tag) {
-				deferred.resolve(tag);
-			})
-			.error(function() {
-				deferred.reject();
-			});
-
-			return deferred.promise;
+			return apiService.put("/api/workgroupView/" + workgroupId + "/tags/" + tag.id, tag);
 		},
 		setInstructorType: function (userRole) {
-			var deferred = $q.defer();
-
-			$http.put(serverRoot + "/api/workgroupView/workgroups/" + userRole.workgroupId + "/userRoles/" + userRole.id + "/instructorTypes/" + userRole.instructorTypeId, { withCredentials: true })
-			.success(function(results) {
-				deferred.resolve(results);
-			})
-			.error(function() {
-				deferred.reject();
-			});
-
-			return deferred.promise;
+			return apiService.put("/api/workgroupView/workgroups/" + userRole.workgroupId + "/userRoles/" + userRole.id + "/instructorTypes/" + userRole.instructorTypeId);
 		},
 		removeTag: function(workgroupId, tag) {
-			var deferred = $q.defer();
-
-			$http.delete(serverRoot + "/api/workgroupView/" + workgroupId + "/tags/" + tag.id, { withCredentials: true })
-			.success(function() {
-				deferred.resolve();
-			})
-			.error(function() {
-				deferred.reject();
-			});
-
-			return deferred.promise;
+			return apiService.delete("/api/workgroupView/" + workgroupId + "/tags/" + tag.id);
 		},
 		addLocation: function (workgroupId, location) {
-			var deferred = $q.defer();
-
-			$http.post(serverRoot + "/api/workgroupView/" + workgroupId + "/locations", location, { withCredentials: true })
-			.success(function(location) {
-				deferred.resolve(location);
-			})
-			.error(function() {
-				deferred.reject();
-			});
-
-			return deferred.promise;
+			return apiService.post("/api/workgroupView/" + workgroupId + "/locations", location);
 		},
 		updateLocation: function (workgroupId, location) {
-			var deferred = $q.defer();
-
-			$http.put(serverRoot + "/api/workgroupView/" + workgroupId + "/locations/" + location.id, location, { withCredentials: true })
-			.success(function(location) {
-				deferred.resolve(location);
-			})
-			.error(function() {
-				deferred.reject();
-			});
-
-			return deferred.promise;
+			return apiService.put("/api/workgroupView/" + workgroupId + "/locations/" + location.id, location);
 		},
 		removeLocation: function(workgroupId, location) {
-			var deferred = $q.defer();
-
-			$http.delete(serverRoot + "/api/workgroupView/" + workgroupId + "/locations/" + location.id, { withCredentials: true })
-			.success(function() {
-				deferred.resolve();
-			})
-			.error(function() {
-				deferred.reject();
-			});
-
-			return deferred.promise;
+			return apiService.delete("/api/workgroupView/" + workgroupId + "/locations/" + location.id);
 		},
 		addRoleToUser: function (workgroupId, user, role) {
-			var deferred = $q.defer();
-
-			$http.post(serverRoot + "/api/workgroupView/users/" + user.loginId + "/workgroups/" + workgroupId + "/roles/" + role.name, null, { withCredentials: true })
-			.success(function(userRole) {
-				deferred.resolve(userRole);
-			})
-			.error(function() {
-				deferred.reject();
-			});
-
-			return deferred.promise;
+			return apiService.post("/api/workgroupView/users/" + user.loginId + "/workgroups/" + workgroupId + "/roles/" + role.name, null);
 		},
 		removeRoleFromUser: function (workgroupId, user, role) {
-			var deferred = $q.defer();
-
-			$http.delete(serverRoot + "/api/workgroupView/users/" + user.loginId + "/workgroups/" + workgroupId + "/roles/" + role.name, { withCredentials: true })
-			.success(function() {
-				deferred.resolve();
-			})
-			.error(function() {
-				deferred.reject();
-			});
-
-			return deferred.promise;
+			return apiService.delete("/api/workgroupView/users/" + user.loginId + "/workgroups/" + workgroupId + "/roles/" + role.name);
 		},
 		searchUsers: function(workgroupId, query) {
-			var deferred = $q.defer();
-
-			$http.get(serverRoot + "/api/people/search?query=" + query, { withCredentials: true })
-			.success(function(result) {
-				deferred.resolve(result);
-			})
-			.error(function() {
-				deferred.reject();
-			});
-
-			return deferred.promise;
+			return apiService.get("/api/people/search?query=" + query);
 		},
 		createUser: function (workgroupId, user) {
-			var deferred = $q.defer();
-
-			$http.post(serverRoot + "/api/workgroupView/workgroups/" + workgroupId + "/users", user, { withCredentials: true })
-			.success(function(newUser) {
-				deferred.resolve(newUser);
-			})
-			.error(function() {
-				deferred.reject();
-			});
-
-			return deferred.promise;
+			return apiService.post("/api/workgroupView/workgroups/" + workgroupId + "/users", user);
 		},
 		removeUserFromWorkgroup: function (workgroupId, user) {
-			var deferred = $q.defer();
-
-			$http.delete(serverRoot + "/api/workgroupView/workgroups/" + workgroupId + "/users/" + user.loginId, { withCredentials: true })
-			.success(function() {
-				deferred.resolve();
-			})
-			.error(function() {
-				deferred.reject();
-			});
-
-			return deferred.promise;
+			return apiService.delete("/api/workgroupView/workgroups/" + workgroupId + "/users/" + user.loginId);
 		},
 		updateUserRole: function (userRole) {
-			var deferred = $q.defer();
-
-			$http.put(serverRoot + "/api/workgroupView/userRoles/" + userRole.id + "/roles/" + userRole.roleId, { withCredentials: true })
-			.success(function(results) {
-				deferred.resolve(results);
-			})
-			.error(function() {
-				deferred.reject();
-			});
-
-			return deferred.promise;
+			return apiService.put("/api/workgroupView/userRoles/" + userRole.id + "/roles/" + userRole.roleId);
 		},
 	};
 });

--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,6 @@
     "angular-selectize2": "3.0.1",
     "angular-bootstrap": "1.3.3",
     "angular-ui-calendar": "1.0.1",
-    "angular-route": "1.5.6",
     "angular-ui-select": "0.19.1",
     "angular-sanitize": "1.5.8",
     "bootstrap": "3.3.6",
@@ -27,11 +26,12 @@
     "ng-idle": "1.3.1",
     "underscore": "1.8.3",
     "toastr": "2.1.2",
-    "angular": "1.5.8"
+    "angular": "1.6.9",
+    "angular-route": "1.6.9"
   },
   "resolutions": {
     "jquery": "2.2.4",
-    "angular": "1.5.8",
+    "angular": "1.6.9",
     "fullcalendar": "2.3.1"
   }
 }


### PR DESCRIPTION
This PR upgrades the frontend to use angularJs 1.6.9
Issue:
https://trello.com/c/BMmsy0Qz/1663-upgrade-to-angularjs-169-1-day

Main issues involved in migrating were:
- Removal of .success()/.failure() in angularJs, which required refactoring of all the service layers. Since they all needed re-writing, I took this opportunity to have them use the apiService to dramatically reduce boilerplate code as well.

- Changes to .success()/.failure() promises also affected uibBootstrap based modals, and required explicit handling of modal closing/canceling.

-Bumping of some angular related dependencies in bower, no side effects have been observed.