### PR TITLE
Bugfix/correctly show instructor summary

### DIFF
--- a/app/assignment/services/assignmentStateService.js
+++ b/app/assignment/services/assignmentStateService.js
@@ -195,26 +195,14 @@ assignmentApp.service('assignmentStateService', function (
 				case INIT_ASSIGNMENT_VIEW:
 					teachingCalls = {
 						ids: [],
-						list: [],
-						eligibleGroups: {}
+						list: []
 					};
-					teachingCalls.eligibleGroups.senateInstructors = true;
-					teachingCalls.eligibleGroups.federationInstructors = true;
 
 					var teachingCallsList = {};
 					var length = action.payload.teachingCalls ? action.payload.teachingCalls.length : 0;
 					for (var i = 0; i < length; i++) {
 						teachingCall = new TeachingCall(action.payload.teachingCalls[i]);
 						teachingCallsList[teachingCall.id] = teachingCall;
-
-						// Gather eligible group data
-						if (teachingCall.sentToSenate) {
-							teachingCalls.eligibleGroups.senateInstructors = false;
-						}
-						if (teachingCall.sentToFederation) {
-							teachingCalls.eligibleGroups.federationInstructors = false;
-						}
-
 					}
 					teachingCalls.ids = _array_sortIdsByProperty(teachingCallsList, ["id"]);
 					teachingCalls.list = teachingCallsList;

--- a/app/shared/entities/CurrentUser.js
+++ b/app/shared/entities/CurrentUser.js
@@ -66,7 +66,7 @@ angular.module('currentUser', ['userRole'])
 			},
 
 			isInstructor: function (workgroupId) {
-				var roleNames = ["federationInstructor", "senateInstructor", "lecturer"];
+				var roleNames = ["instructor"];
 				return this.hasRoles(roleNames, workgroupId);
 			},
 

--- a/app/summary/SummaryCtrl.js
+++ b/app/summary/SummaryCtrl.js
@@ -31,7 +31,7 @@ summaryApp.controller('SummaryCtrl', ['$scope', '$routeParams', '$rootScope', '$
 			var isAdmin = currentUser.isAdmin();
 			var isAcademicPlanner = currentUser.hasRole('academicPlanner', $scope.workgroupId);
 			var isReviewer = currentUser.hasRole('reviewer', $scope.workgroupId);
-			var isInstructor = currentUser.hasRoles(['senateInstructor', 'federationInstructor'], $scope.workgroupId);
+			var isInstructor = currentUser.isInstructor($scope.workgroupId);
 			var isInstructionalSupport = currentUser.hasRoles(['studentMasters', 'studentPhd', 'instructionalSupport'], $scope.workgroupId);
 
 			if (isAcademicPlanner || isReviewer || isAdmin) {

--- a/app/supportAssignment/SupportAssignmentCtrl.js
+++ b/app/supportAssignment/SupportAssignmentCtrl.js
@@ -46,7 +46,7 @@ supportAssignmentApp.controller('SupportAssignmentCtrl', ['$scope', '$rootScope'
 						// Check if this is an instructor reviewing the support assignments
 						if (isInstructorReviewOpen) {
 							userRoles.forEach(function(userRole) {
-								if (userRole.roleName == "federationInstructor" || userRole.roleName == "senateInstructor") {
+								if (userRole.roleName == "instructor") {
 									$scope.isAllowed = true;
 									$scope.readOnlyMode = true;
 								}

--- a/app/teachingCall/teachingCallStatus/controllers/ModalAddInstructorsCtrl.js
+++ b/app/teachingCall/teachingCallStatus/controllers/ModalAddInstructorsCtrl.js
@@ -80,10 +80,6 @@ teachingCallApp.controller('ModalAddInstructorsCtrl', ['$scope', '$rootScope', '
 	$scope.minDate = new Date();
 	$scope.parent = {dueDate:''};
 
-	$scope.senateInstructors = {};
-	$scope.federationInstructors = {};
-	$scope.lecturerInstructors = {};
-
 	$scope.startTeachingCallConfig.activeTerms = {};
 
 	allTerms = ['01', '02', '03', '04', '05', '06', '07', '08', '09', '10'];

--- a/app/teachingCall/teachingCallStatus/controllers/ModalContactInstructorsCtrl.js
+++ b/app/teachingCall/teachingCallStatus/controllers/ModalContactInstructorsCtrl.js
@@ -117,14 +117,6 @@ teachingCallApp.controller('ModalContactInstructorsCtrl', this.ModalContactInstr
 		$scope.startTeachingCallConfig.activeTerms[term] = !$scope.startTeachingCallConfig.activeTerms[term];
 	};
 
-	$scope.toggleSenateInstructors = function () {
-		$scope.startTeachingCallConfig.sentToSenate = !$scope.startTeachingCallConfig.sentToSenate;
-	};
-
-	$scope.toggleFederationInstructors = function () {
-		$scope.startTeachingCallConfig.sentToFederation = !$scope.startTeachingCallConfig.sentToFederation;
-	};
-
 	// Datepicker config
 	$scope.inlineOptions = {
 		minDate: new Date(),

--- a/app/teachingCall/teachingCallStatus/controllers/ModalTeachingCallConfigCtrl.js
+++ b/app/teachingCall/teachingCallStatus/controllers/ModalTeachingCallConfigCtrl.js
@@ -24,9 +24,6 @@ teachingCallApp.controller('ModalTeachingCallConfigCtrl', this.ModalTeachingCall
 	$scope.minDate = new Date();
 	$scope.parent = {dueDate:''};
 
-	$scope.senateInstructors = {};
-	$scope.federationInstructors = {};
-
 	$scope.startTeachingCallConfig.activeTerms = {};
 	$scope.allTerms = allTerms;
 	$scope.displayedFormPage = 1;
@@ -101,14 +98,6 @@ teachingCallApp.controller('ModalTeachingCallConfigCtrl', this.ModalTeachingCall
 	$scope.toggleTermActive = function (term) {
 		term = term.slice(-2);
 		$scope.startTeachingCallConfig.activeTerms[term] = !$scope.startTeachingCallConfig.activeTerms[term];
-	};
-
-	$scope.toggleSenateInstructors = function () {
-		$scope.startTeachingCallConfig.sentToSenate = !$scope.startTeachingCallConfig.sentToSenate;
-	};
-
-	$scope.toggleFederationInstructors = function () {
-		$scope.startTeachingCallConfig.sentToFederation = !$scope.startTeachingCallConfig.sentToFederation;
 	};
 
 	// Datepicker config

--- a/app/teachingCall/teachingCallStatus/services/teachingCallStatusSelectors.js
+++ b/app/teachingCall/teachingCallStatus/services/teachingCallStatusSelectors.js
@@ -24,7 +24,7 @@
 teachingCallApp.service('teachingCallStatusSelectors', function () {
 	return {
 
-		generateInstructorGroup: function (instructors, teachingCallReceipts, inTeachingCall, inSenate, inFederation, inLecturer) {
+		generateInstructorGroup: function (instructors, teachingCallReceipts, inTeachingCall) {
 			generatedInstructors = [];
 			self = this;
 
@@ -33,10 +33,7 @@ teachingCallApp.service('teachingCallStatusSelectors', function () {
 				var teachingCallReceipt = teachingCallReceipts.list[instructor.teachingCallReceiptId];
 				var isInstructorInTeachingCall = teachingCallReceipt ? true : false;
 
-				if (inTeachingCall == isInstructorInTeachingCall
-				&& inSenate == instructor.isSenateInstructor
-				&& inFederation == instructor.isFederationInstructor
-				&& inLecturer == instructor.isLecturerInstructor) {
+				if (inTeachingCall == isInstructorInTeachingCall) {
 					var viewInstructor = self.generateInstructor(instructor, teachingCallReceipt);
 					generatedInstructors.push(viewInstructor);
 				}

--- a/app/workgroup/controllers/ModalImpersonateCtrl.js
+++ b/app/workgroup/controllers/ModalImpersonateCtrl.js
@@ -17,8 +17,7 @@ workgroupApp.controller('ModalImpersonateCtrl', this.ModalImpersonateCtrl = func
 		user.userRoles.forEach( function(userRole) {
 			if (userRole.role == "studentMasters"
 			|| userRole.role == "studentPhd"
-			|| userRole.role == "senateInstructor"
-			|| userRole.role == "federationInstructor"
+			|| userRole.role == "instructor"
 			|| userRole.role == "instructionalSupport") {
 					canBeImpersonated = true;
 				}


### PR DESCRIPTION
Bug occurs when summary screen needs to generate the summary page mode itself, currently the summary screen is looking for the old instructor user roles to determine if someone is an 'instructor'.

Also fixes misc other references to senate/federation across IPA.

Recommend merging straight to master as this is a fairly severe bug.

Issue:
https://trello.com/c/UjwXJAyx/1696-cs-instructors-getting-unknown-user-role-errors