### PR TITLE
Budget: Change revert tooltips to say 'Update'

### DIFF
--- a/app/budget/directives/courseCosts/courseCosts.html
+++ b/app/budget/directives/courseCosts/courseCosts.html
@@ -110,11 +110,11 @@
 								</ipa-input>
 							</div>
 							<div class="glyphicon glyphicon-repeat course-costs__revert-ui"
-							     uib-tooltip="Revert to schedule total seats of {{ !!(sectionGroup.totalSeats) ? sectionGroup.totalSeats : 'none' }}"
+							     uib-tooltip="Update to schedule total seats of {{ !!(sectionGroup.totalSeats) ? sectionGroup.totalSeats : 'none' }}"
 							     tooltip-append-to-body="true"
 							     confirm-button="revertOverride(sectionGroup, 'seats')"
-							     message="Revert to schedule total seats of {{ !!(sectionGroup.totalSeats) ? sectionGroup.totalSeats : 'none' }}?"
-							     yes="Revert"
+							     message="Update to schedule total seats of {{ !!(sectionGroup.totalSeats) ? sectionGroup.totalSeats : 'none' }}?"
+							     yes="Update"
 							     no="Cancel"
 							     ng-show="!!(sectionGroup.sectionGroupCost) && sectionGroup.sectionGroupCost.enrollment !== null && (sectionGroup.totalSeats != sectionGroup.sectionGroupCost.enrollment)">
 							</div>
@@ -130,11 +130,11 @@
 								</ipa-input>
 							</div>
 							<div class="glyphicon glyphicon-repeat course-costs__revert-ui"
-							     uib-tooltip="Revert to schedule section count of {{ !!(sectionGroup.sectionCount) ? sectionGroup.sectionCount : 'none' }}"
+							     uib-tooltip="Update to schedule section count of {{ !!(sectionGroup.sectionCount) ? sectionGroup.sectionCount : 'none' }}"
 							     tooltip-append-to-body="true"
 							     confirm-button="revertOverride(sectionGroup, 'sectionCount')"
-							     message="Revert to schedule section count of {{ !!(sectionGroup.sectionCount) ? sectionGroup.sectionCount : 'none' }}?"
-							     yes="Revert"
+							     message="Update to schedule section count of {{ !!(sectionGroup.sectionCount) ? sectionGroup.sectionCount : 'none' }}?"
+							     yes="Update"
 							     no="Cancel"
 							     ng-show="!!(sectionGroup.sectionGroupCost) && sectionGroup.sectionGroupCost.sectionCount !== null && sectionGroup.sectionCount != sectionGroup.sectionGroupCost.sectionCount">
 							</div>
@@ -150,11 +150,11 @@
 								</ipa-input>
 							</div>
 							<div class="glyphicon glyphicon-repeat course-costs__revert-ui"
-							     uib-tooltip="Revert to schedule TA count of {{ !!(sectionGroup.teachingAssistantAppointments) ? sectionGroup.teachingAssistantAppointments : 'none' }}"
+							     uib-tooltip="Update to schedule TA count of {{ !!(sectionGroup.teachingAssistantAppointments) ? sectionGroup.teachingAssistantAppointments : 'none' }}"
 							     tooltip-append-to-body="true"
 							     confirm-button="revertOverride(sectionGroup, 'teachingAssistantAppointments')"
-							     message="Revert to schedule TA count of {{ !!(sectionGroup.teachingAssistantAppointments) ? sectionGroup.teachingAssistantAppointments : 'none' }}?"
-							     yes="Revert"
+							     message="Update to schedule TA count of {{ !!(sectionGroup.teachingAssistantAppointments) ? sectionGroup.teachingAssistantAppointments : 'none' }}?"
+							     yes="Update"
 							     no="Cancel"
 							     ng-show="!!(sectionGroup.sectionGroupCost) && sectionGroup.sectionGroupCost.taCount !== null && sectionGroup.teachingAssistantAppointments != sectionGroup.sectionGroupCost.taCount">
 							</div>
@@ -174,11 +174,11 @@
 								</ipa-input>
 							</div>
 							<div class="glyphicon glyphicon-repeat course-costs__revert-ui"
-							     uib-tooltip="Revert to schedule reader count of {{ !!(sectionGroup.readerAppointments) ? sectionGroup.readerAppointments : 'none' }}"
+							     uib-tooltip="Update to schedule reader count of {{ !!(sectionGroup.readerAppointments) ? sectionGroup.readerAppointments : 'none' }}"
 							     tooltip-append-to-body="true"
 							     confirm-button="revertOverride(sectionGroup, 'readerAppointments')"
-							     message="Revert to schedule reader count of {{ !!(sectionGroup.readerAppointments) ? sectionGroup.readerAppointments : 'none' }}?"
-							     yes="Revert"
+							     message="Update to schedule reader count of {{ !!(sectionGroup.readerAppointments) ? sectionGroup.readerAppointments : 'none' }}?"
+							     yes="Update"
 							     no="Cancel"
 							     ng-show="!!(sectionGroup.sectionGroupCost) && sectionGroup.sectionGroupCost.readerCount !== null && sectionGroup.readerAppointments != sectionGroup.sectionGroupCost.readerCount">
 							</div>

--- a/app/budget/directives/instructorCosts/instructorCosts.html
+++ b/app/budget/directives/instructorCosts/instructorCosts.html
@@ -95,11 +95,11 @@
 							</div>
 							<div class="instructor-costs__instructor-reversion-ui">
 								<div class="glyphicon glyphicon-repeat instructor-costs__revert-ui"
-								     uib-tooltip="Revert to {{ sectionGroup.reversionDisplayName }}"
+								     uib-tooltip="Update to {{ sectionGroup.reversionDisplayName }}"
 								     tooltip-append-to-body="true"
 								     confirm-button="removeInstructor(sectionGroup.sectionGroupCost)"
-								     message="Revert to {{ sectionGroup.reversionDisplayName }}?"
-								     yes="Revert"
+								     message="Update to {{ sectionGroup.reversionDisplayName }}?"
+								     yes="Update"
 								     no="Cancel"
 								     ng-show="sectionGroup.reversionDisplayName">
 								</div>


### PR DESCRIPTION
Issue:
https://trello.com/c/nmiGjLYJ/1692-revert-tooltips-should-be-re-labeled-as-update-as-they-are-not-always-reverting