### PR TITLE
Add automatic line items for course releases

### DIFF
--- a/app/budget/services/actions/budgetCalculations.js
+++ b/app/budget/services/actions/budgetCalculations.js
@@ -426,7 +426,7 @@ class BudgetCalculations {
 	
 					if (teachingAssignment.approved == false) { return; }
 	
-					if (teachingAssignment.buyout || teachingAssignment.workLifeBalance) {
+					if (teachingAssignment.buyout || teachingAssignment.workLifeBalance || teachingAssignment.courseRelease) {
 						if (self._matchingLineItemExists(teachingAssignment, BudgetReducers._state.lineItems) == false) {
 							let lineItem = self.scaffoldLineItem(teachingAssignment);
 							calculatedLineItems.push(lineItem);
@@ -505,6 +505,9 @@ class BudgetCalculations {
 				} else if (teachingAssignment.workLifeBalance) {
 					typeDescription = "Work-Life Balance";
 					lineItemCategoryId = 5;
+				} else if (teachingAssignment.courseRelease) {
+					typeDescription = "Course Release";
+					lineItemCategoryId = 6;
 				}
 	
 				var categoryDescription = BudgetReducers._state.lineItemCategories.list[lineItemCategoryId].description;


### PR DESCRIPTION
Issue:
https://trello.com/c/m99L7XRO/1748-budget-module-course-releases-granted-in-instructor-assignments-should-also-be-automatic-line-items

<img width="1173" alt="screen shot 2018-06-08 at 10 06 34 am" src="https://user-images.githubusercontent.com/1776859/41170967-99cb77f2-6b03-11e8-813d-c24767e854f7.png">
