### PR TITLE
BudgetView: Fix safari bug with line item modal

### DIFF
--- a/app/budget/directives/modals/addLineItemComments/addLineItemComments.css
+++ b/app/budget/directives/modals/addLineItemComments/addLineItemComments.css
@@ -1,12 +1,15 @@
 .add-line-item-comments {
 	padding: 4%;
-	max-height: 500px;
 }
 
-.add-line-item-comments .comment-container {
+.add-line-item__comment-container {
 	border: 1px solid #c1c1c1;
 	border-radius: 4px;
 	margin-bottom: 2%;
+}
+
+.add-line-item__comment-container--last {
+	margin-bottom: 0px;
 }
 
 .add-line-item-comments .comment-header {

--- a/app/budget/directives/modals/addLineItemComments/addLineItemComments.html
+++ b/app/budget/directives/modals/addLineItemComments/addLineItemComments.html
@@ -23,11 +23,11 @@
 		</div>
 	</div> <!-- input container -->
 
-	<div ng-repeat="comment in lineItem.comments" class="comment-container">
+	<div ng-repeat="comment in lineItem.comments" class="add-line-item__comment-container" ng-class="{'add-line-item__comment-container--last' : $last }">
 		<div class="comment-header">
 			{{ comment.authorName }}&nbsp;
 			<span class="comment-date" uib-tooltip="{{ dateToCalendar(comment.lastModifiedOn) }}">
-				({{ dateToRelative(comment.lastModifiedOn) }})
+				({{ dateToRelative(comment.lastModifiedOn) }}) - [{{$last}}]
 			</span>
 		</div>
 		<div class="comment-body">


### PR DESCRIPTION
Safari had a different interpretation of what to do with overflow: scroll and max-height than the other browsers. In this case, the max-height was unnecessary, so removing it and adding a style to ensure consistent padding for the bottom comment resolved the issue.

Issue:
https://trello.com/c/VrBBdqDq/1758-budget-comments-modal-needs-inner-padding-at-bottom