### PR TITLE
Bugfix/new scenario bugs

### DIFF
--- a/app/budget/directives/budgetCosts/courseCostsRow/courseCostsRow.html
+++ b/app/budget/directives/budgetCosts/courseCostsRow/courseCostsRow.html
@@ -23,7 +23,7 @@
 			     message="Update to schedule total seats of {{ !!(sectionGroup.totalSeats) ? sectionGroup.totalSeats : 'none' }}?"
 			     yes="Update"
 			     no="Cancel"
-			     ng-show="!!(sectionGroup.sectionGroupCost) && sectionGroup.sectionGroupCost.enrollment !== null && (sectionGroup.totalSeats != sectionGroup.sectionGroupCost.enrollment)">
+			     ng-show="!!(sectionGroup.sectionGroupCost) && !!(sectionGroup.sectionGroupCost.enrollment) && (sectionGroup.totalSeats != sectionGroup.sectionGroupCost.enrollment)">
 			</div>
 		</div>
 	</td>
@@ -46,7 +46,7 @@
 			     message="Update to schedule section count of {{ !!(sectionGroup.sectionCount) ? sectionGroup.sectionCount : 'none' }}?"
 			     yes="Update"
 			     no="Cancel"
-			     ng-show="!!(sectionGroup.sectionGroupCost) && sectionGroup.sectionGroupCost.sectionCount !== null && sectionGroup.sectionCount != sectionGroup.sectionGroupCost.sectionCount">
+			     ng-show="!!(sectionGroup.sectionGroupCost) && !!(sectionGroup.sectionGroupCost.sectionCount) && sectionGroup.sectionCount != sectionGroup.sectionGroupCost.sectionCount">
 			</div>
 		</div>
 	</td>

--- a/app/budget/directives/budgetCosts/instructorCostsRow/instructorCostsRow.html
+++ b/app/budget/directives/budgetCosts/instructorCostsRow/instructorCostsRow.html
@@ -59,7 +59,7 @@
 		</div>
 		<div class="instructor-costs__cost-container">
 			<ipa-input value="sectionGroup.sectionGroupCost.reason"
-			           on-update="updateReason(sectionGroup)">
+			           on-update="overrideSectionGroup(sectionGroup, 'reason')">
 			</ipa-input>
 		</div>
 	</td>
@@ -73,7 +73,7 @@
 			<div ng-if="sectionGroup.overrideInstructorCostSource == 'course'">
 				<ipa-input mode="'currency'"
 				           value="sectionGroup.overrideInstructorCost"
-				           on-update="updateInstructorCost(sectionGroup.sectionGroupCost, sectionGroup.overrideInstructorCost)">
+				           on-update="updateInstructorCost(sectionGroup)">
 				</ipa-input>
 			</div>
 

--- a/app/budget/directives/budgetCosts/instructorCostsRow/instructorCostsRow.html
+++ b/app/budget/directives/budgetCosts/instructorCostsRow/instructorCostsRow.html
@@ -59,7 +59,7 @@
 		</div>
 		<div class="instructor-costs__cost-container">
 			<ipa-input value="sectionGroup.sectionGroupCost.reason"
-			           on-update="updateSectionGroupCost(sectionGroup.sectionGroupCost)">
+			           on-update="updateReason(sectionGroup)">
 			</ipa-input>
 		</div>
 	</td>

--- a/app/budget/directives/budgetCosts/instructorCostsRow/instructorCostsRow.js
+++ b/app/budget/directives/budgetCosts/instructorCostsRow/instructorCostsRow.js
@@ -31,14 +31,14 @@ let instructorCostsRow = function ($rootScope, BudgetActions) {
 				return toCurrency(value);
 			};
 
-			scope.updateInstructorCost = function(sectionGroupCost, overrideInstructorCost) {
-				sectionGroupCost.cost = angular.copy(parseFloat(overrideInstructorCost));
+			scope.updateInstructorCost = function(sectionGroup, overrideInstructorCost) {
+				sectionGroup.cost = angular.copy(parseFloat(sectionGroup.overrideInstructorCost));
 
-				scope.updateSectionGroupCost(sectionGroupCost);
+				scope.overrideSectionGroup(sectionGroup, 'instructorCost');
 			};
 
-			scope.updateReason = function(sectionGroup) {
-				BudgetActions.overrideSectionGroup(sectionGroup, "reason");
+			scope.overrideSectionGroup = function(sectionGroup, property) {
+				BudgetActions.overrideSectionGroup(sectionGroup, property);
 			};
 		} // end link
 	};

--- a/app/budget/directives/budgetCosts/instructorCostsRow/instructorCostsRow.js
+++ b/app/budget/directives/budgetCosts/instructorCostsRow/instructorCostsRow.js
@@ -37,8 +37,8 @@ let instructorCostsRow = function ($rootScope, BudgetActions) {
 				scope.updateSectionGroupCost(sectionGroupCost);
 			};
 
-			scope.updateSectionGroupCost = function(sectionGroupCost) {
-				BudgetActions.updateSectionGroupCost(sectionGroupCost);
+			scope.updateReason = function(sectionGroup) {
+				BudgetActions.overrideSectionGroup(sectionGroup, "reason");
 			};
 		} // end link
 	};

--- a/app/budget/services/actions/budgetActions.js
+++ b/app/budget/services/actions/budgetActions.js
@@ -9,7 +9,7 @@ class BudgetActions {
 				var year = $route.current.params.year;
 
 				BudgetService.getInitialState(workgroupId, year).then(function (results) {
-	
+
 					// BudgetScenario was set in localStorage, need to sanity check
 					if (selectedBudgetScenarioId) {
 						var scenarioFound = false;
@@ -18,12 +18,12 @@ class BudgetActions {
 								scenarioFound = true;
 							}
 						});
-	
+
 						if (scenarioFound == false) {
 							selectedBudgetScenarioId = null;
 						}
 					}
-	
+
 					// BudgetScenario was not set in localStorage, or it didn't correspond to an existing scenario
 					if (!selectedBudgetScenarioId) {
 						if (results.budgetScenarios && results.budgetScenarios.length > 0) {
@@ -31,7 +31,7 @@ class BudgetActions {
 							localStorage.setItem('selectedBudgetScenarioId', selectedBudgetScenarioId);
 						}
 					}
-	
+
 					BudgetReducers.reduce({
 						type: ActionTypes.INIT_STATE,
 						payload: results,
@@ -40,7 +40,7 @@ class BudgetActions {
 						selectedBudgetScenarioId: selectedBudgetScenarioId,
 						selectedTerm: selectedTerm
 					});
-	
+
 					// Ensure budgetScenario is properly set
 					self.selectBudgetScenario();
 					self.attachInstructorTypesToInstructors();
@@ -59,19 +59,19 @@ class BudgetActions {
 				var oldValue = null;
 				var newValue = null;
 				var savedOverride = null;
-	
+
 				var newSectionGroupCost = {
 					sectionGroupId: sectionGroup.id,
 					budgetScenarioId: BudgetReducers._state.ui.selectedBudgetScenarioId
 				};
-	
+
 				if (property == "seats") {
 					savedOverride = sectionGroup.sectionGroupCost ? sectionGroup.sectionGroupCost.enrollment : null;
 					oldValue = savedOverride || sectionGroup.totalSeats;
 					newValue = this._calculateNewValue(sectionGroup.overrideTotalSeats, isReversion);
 					newSectionGroupCost.enrollment = sectionGroup.overrideTotalSeats;
 				}
-	
+
 				else if (property == "sectionCount") {
 					savedOverride = sectionGroup.sectionGroupCost ? sectionGroup.sectionGroupCost.sectionCount : null;
 					oldValue = savedOverride || sectionGroup.sectionCount;
@@ -104,13 +104,12 @@ class BudgetActions {
 					newValue = savedOverride || sectionGroup.overrideInstructorCost;
 					newSectionGroupCost.cost = sectionGroup.cost;
 				}
-	
+
 				var isOverriden = oldValue != newValue;
 				var wasOverriden = !!(savedOverride);
-	
+
 				if (isOverriden) {
 					// Create or update sectionGroupCost
-					debugger;
 					if (sectionGroup.sectionGroupCost && sectionGroup.sectionGroupCost.id) {
 						sectionGroup.sectionGroupCost = this.applyOverrideToProperty(sectionGroup.sectionGroupCost, newValue, property);
 						this.updateSectionGroupCost(sectionGroup.sectionGroupCost);
@@ -154,10 +153,10 @@ class BudgetActions {
 			},
 			updateBudgetScenario: function (budgetScenario) {
 				var self = this;
-	
+
 				BudgetService.updateBudgetScenario(budgetScenario).then(function (results) {
 					$rootScope.$emit('toast', { message: "Updated budget scenario", type: "SUCCESS" });
-	
+
 					BudgetReducers.reduce({
 						type: ActionTypes.UPDATE_BUDGET_SCENARIO,
 						payload: {
@@ -196,7 +195,7 @@ class BudgetActions {
 			},
 			deleteBudgetScenario: function (budgetScenarioId) {
 				var self = this;
-	
+
 				BudgetService.deleteBudgetScenario(budgetScenarioId).then(function (budgetScenarioId) {
 					var action = {
 						type: ActionTypes.DELETE_BUDGET_SCENARIO,
@@ -204,7 +203,7 @@ class BudgetActions {
 							budgetScenarioId: budgetScenarioId
 						}
 					};
-	
+
 					$rootScope.$emit('toast', { message: "Deleted budget scenario", type: "SUCCESS" });
 					BudgetReducers.reduce(action);
 					self.selectBudgetScenario();
@@ -215,10 +214,10 @@ class BudgetActions {
 			updateInstructorCost: function (instructorCostDto) {
 				var self = this;
 				var instructorCost = Object.assign({}, instructorCostDto);
-	
+
 				// Ensure cost is passed as a number
 				instructorCost.cost = parseFloat(instructorCost.cost);
-	
+
 				BudgetService.updateInstructorCost(instructorCost).then(function (newInstructorCost) {
 					var action = {
 						type: ActionTypes.UPDATE_INSTRUCTOR_COST,
@@ -311,14 +310,14 @@ class BudgetActions {
 			},
 			deleteLineItem: function(lineItem) {
 				var self = this;
-	
+
 				// If the lineItem is based on a teachingAssignment, do not delete it, instead mark it as hidden
 				if (lineItem.teachingAssignmentId > 0) {
 					lineItem.hidden = true;
 					this.updateLineItem(lineItem);
 					return;
 				}
-	
+
 				BudgetService.deleteLineItem(lineItem).then(function (lineItemId) {
 					var action = {
 						type: ActionTypes.DELETE_LINE_ITEM,
@@ -326,7 +325,7 @@ class BudgetActions {
 							lineItemId: lineItemId
 						}
 					};
-	
+
 					$rootScope.$emit('toast', { message: "Deleted line item", type: "SUCCESS" });
 					BudgetReducers.reduce(action);
 					BudgetCalculations.calculateLineItems();
@@ -353,7 +352,7 @@ class BudgetActions {
 			},
 			createSectionGroupCost: function (sectionGroupCost) {
 				var self = this;
-	
+
 				BudgetService.createSectionGroupCost(sectionGroupCost).then(function (newSectionGroupCost) {
 					var action = {
 						type: ActionTypes.CREATE_SECTION_GROUP_COST,
@@ -371,7 +370,7 @@ class BudgetActions {
 			},
 			asignInstructorType: function(instructorCost) {
 				var self = this;
-	
+
 				BudgetService.updateInstructorCost(instructorCost).then(function (newInstructorCost) {
 					var action = {
 						type: ActionTypes.UPDATE_INSTRUCTOR_COST,
@@ -399,7 +398,7 @@ class BudgetActions {
 			_createInstructorTypeCost: function (instructorTypeCostDTO) {
 				var self = this;
 				instructorTypeCostDTO.cost = parseFloat(instructorTypeCostDTO.cost);
-	
+
 				BudgetService.createInstructorTypeCost(instructorTypeCostDTO).then(function (instructorTypeCost) {
 					BudgetReducers.reduce({
 						type: ActionTypes.CREATE_INSTRUCTOR_TYPE_COST,
@@ -407,7 +406,7 @@ class BudgetActions {
 							instructorTypeCost: instructorTypeCost
 						}
 					});
-	
+
 					$rootScope.$emit('toast', { message: "Updated instructor type", type: "SUCCESS" });
 					BudgetCalculations.calculateInstructorTypeCosts();
 					BudgetCalculations.calculateSectionGroups();

--- a/app/budget/services/actions/budgetActions.js
+++ b/app/budget/services/actions/budgetActions.js
@@ -91,10 +91,18 @@ class BudgetActions {
 					oldValue = savedOverride || sectionGroup.readerAppointments;
 					newValue = this._calculateNewValue(sectionGroup.overrideReaderAppointments, isReversion);
 					newSectionGroupCost.readerCount = sectionGroup.overrideReaderAppointments;
-				} else if (property == "reason") {
+				}
+
+				else if (property == "reason") {
 					oldValue = null;
 					newValue = sectionGroup.sectionGroupCost.reason;
 					newSectionGroupCost.reason = sectionGroup.sectionGroupCost.reason;
+				}
+
+				else if (property == "instructorCost") {
+					oldValue = null;
+					newValue = savedOverride || sectionGroup.overrideInstructorCost;
+					newSectionGroupCost.cost = sectionGroup.cost;
 				}
 	
 				var isOverriden = oldValue != newValue;
@@ -102,6 +110,7 @@ class BudgetActions {
 	
 				if (isOverriden) {
 					// Create or update sectionGroupCost
+					debugger;
 					if (sectionGroup.sectionGroupCost && sectionGroup.sectionGroupCost.id) {
 						sectionGroup.sectionGroupCost = this.applyOverrideToProperty(sectionGroup.sectionGroupCost, newValue, property);
 						this.updateSectionGroupCost(sectionGroup.sectionGroupCost);
@@ -137,6 +146,8 @@ class BudgetActions {
 					sectionGroupCost.readerCount = value;
 				} else if (property == "reason") {
 					sectionGroupCost.reason = value;
+				} else if (property == "instructorCost") {
+					sectionGroupCost.cost = parseFloat(value);
 				}
 	
 				return sectionGroupCost;


### PR DESCRIPTION
The bug was triggered by editing the reason or cost values when the sectionGroupCost did not already exist.

In this scenario:
- Erroneous checks in the template of other values caused the reversion UI to appear incorrectly.
Some symptoms were caused by erroneous checks in the template for existence.
- State was improperly updated.
