### PR TITLE
Bugfix/scheduling freeform date time

### DIFF
--- a/app/scheduling/controllers/SchedulingCtrl.js
+++ b/app/scheduling/controllers/SchedulingCtrl.js
@@ -139,14 +139,6 @@ class SchedulingCtrl {
 			self.$scope.saveActivity();
 		};
 
-		self.$scope.toggleActivityDay = function (index) {
-			var activity = self.$scope.view.state.activities.list[self.$scope.view.state.uiState.selectedActivityId];
-			var dayArr = activity.dayIndicator.split('');
-			dayArr[index] = Math.abs(1 - parseInt(dayArr[index])).toString();
-			activity.dayIndicator = dayArr.join('');
-			self.$scope.saveActivity();
-		};
-
 		self.$scope.setActivityStandardTime = function (time) {
 			var activity = self.$scope.view.state.activities.list[self.$scope.view.state.uiState.selectedActivityId];
 			activity.frequency = 1;

--- a/app/scheduling/directives/activityDetails/timeEditor/freeformTimeSelector/freeformTimeSelector.html
+++ b/app/scheduling/directives/activityDetails/timeEditor/freeformTimeSelector/freeformTimeSelector.html
@@ -6,9 +6,13 @@
 			</label>
 			<div class="col-sm-5" style="padding-left: 0;">
 				<div class="input-group input-group-sm">
-					<input auto-input type="number" class="form-control" on-enter="saveActivity()" on-blur="saveActivity()"
-						help-text-placement="top" ng-model="activity.frequency"
-					/>
+					<input auto-input
+					       type="number"
+					       class="form-control"
+					       on-enter="saveActivity()"
+					       on-blur="saveActivity()"
+					       help-text-placement="top"
+					       ng-model="activity.frequency"/>
 					<span class="input-group-addon">weeks</span>
 				</div>
 			</div>

--- a/app/scheduling/directives/activityDetails/timeEditor/freeformTimeSelector/freeformTimeSelector.js
+++ b/app/scheduling/directives/activityDetails/timeEditor/freeformTimeSelector/freeformTimeSelector.js
@@ -8,10 +8,12 @@ let freeformTimeSelector = function (SchedulingActionCreators) {
 			activity: '='
 		},
 		link: function (scope, element, attrs) {
+			scope.days = ['U', 'M', 'T', 'W', 'R', 'F', 'S'];
+
 			// Ensure activity startTime precedes endTime before submission
 			scope.saveActivity = function() {
-				startTime = moment(scope.activity.startTime, "HH:mm");
-				endTime = moment(scope.activity.endTime, "HH:mm");
+				var startTime = moment(scope.activity.startTime, "HH:mm");
+				var endTime = moment(scope.activity.endTime, "HH:mm");
 
 				if (startTime.isAfter(endTime) || startTime.isSame(endTime)) {
 					endTime = startTime.add(5, "minutes");
@@ -19,6 +21,13 @@ let freeformTimeSelector = function (SchedulingActionCreators) {
 				}
 
 				SchedulingActionCreators.updateActivity(scope.activity);
+			};
+
+			scope.toggleActivityDay = function (index) {
+				var dayArr = scope.activity.dayIndicator.split('');
+				dayArr[index] = Math.abs(1 - parseInt(dayArr[index])).toString();
+				scope.activity.dayIndicator = dayArr.join('');
+				scope.saveActivity();
 			};
 		}
 	};

--- a/app/scheduling/directives/timeInput/timeInput.js
+++ b/app/scheduling/directives/timeInput/timeInput.js
@@ -34,8 +34,8 @@ let timeInput = function ($timeout) {
 				scope.canIncrementMinutes = true;
 
 				var selectedTime = moment(scope.time, "HH:mm:ss");
-				selectedMinutes = selectedTime.minutes();
-				selectedHours = selectedTime.hours();
+				var selectedMinutes = selectedTime.minutes();
+				var selectedHours = selectedTime.hours();
 
 				if (selectedMinutes == "55") {
 					scope.canIncrementMinutes = false;
@@ -49,8 +49,8 @@ let timeInput = function ($timeout) {
 					var floorTime = moment(scope.floor, "HH:mm:ss");
 					floorTime = floorTime.add(5, "minutes");
 
-					floorMinutes = floorTime.minutes();
-					floorHours = floorTime.hours();
+					var floorMinutes = floorTime.minutes();
+					var floorHours = floorTime.hours();
 
 
 					if (floorHours == selectedHours && floorMinutes == selectedMinutes) {
@@ -70,8 +70,8 @@ let timeInput = function ($timeout) {
 					var ceilingTime = moment(scope.ceiling, "HH:mm:ss");
 					ceilingTime = ceilingTime.subtract(5, "minutes");
 
-					ceilingMinutes = ceilingTime.minutes();
-					ceilingHours = ceilingTime.hours();
+					var ceilingMinutes = ceilingTime.minutes();
+					var ceilingHours = ceilingTime.hours();
 
 					if (ceilingHours == selectedHours && ceilingMinutes == selectedMinutes) {
 						scope.canIncrementMinutes = false;

--- a/app/scheduling/schedulingApp.js
+++ b/app/scheduling/schedulingApp.js
@@ -19,7 +19,7 @@ import timeInput from './directives/timeInput/timeInput.js';
 import activityDetails from './directives/activityDetails/activityDetails.js';
 import locationEditor from './directives/activityDetails/locationEditor/locationEditor.js';
 import timeEditor from './directives/activityDetails/timeEditor/timeEditor.js';
-import freeformTimeInput from './directives/activityDetails/timeEditor/freeformTimeSelector/freeformTimeSelector.js';
+import freeformTimeSelector from './directives/activityDetails/timeEditor/freeformTimeSelector/freeformTimeSelector.js';
 import standardTimeSelector from './directives/activityDetails/timeEditor/standardTimeSelector/standardTimeSelector.js';
 
 // Dependencies
@@ -78,7 +78,7 @@ const schedulingApp = angular.module("schedulingApp", dependencies)
 .directive('activityDetails', activityDetails)
 .directive('locationEditor', locationEditor)
 .directive('timeEditor', timeEditor)
-.directive('freeformTimeInput', freeformTimeInput)
+.directive('freeformTimeSelector', freeformTimeSelector)
 .directive('standardTimeSelector', standardTimeSelector)
 .constant('ActionTypes', {
 	INIT_STATE: "INIT_STATE",


### PR DESCRIPTION
The freeform day / time selectors were broken in a way that didn't generate errors, during the ES6 migration. This PR restores their functionality.

Issue:
https://trello.com/c/pn41uzu1/1774-schedulingview-cant-set-custom-times