### PR TITLE
Fix ordering of students in support assignment course dropdown

### DIFF
--- a/app/supportAssignment/directives/supportAssignmentTable/supportCoursesTab/assignSupportStaff/assignSupportStaff.html
+++ b/app/supportAssignment/directives/supportAssignmentTable/supportCoursesTab/assignSupportStaff/assignSupportStaff.html
@@ -69,11 +69,7 @@
 			<div class="assign-support-staff__dropdown-item"
 				ng-repeat="preference in assignmentOptions.other"
 				ng-click="triggerSelection(preference)">
-				<div class="assign-support-staff__priority-icon">
-					<div class="badge badge-pill badge-dark">
-						{{ preference.priority }}
-					</div>
-				</div>
+
 				<div class="assign-support-staff__description">
 					{{ preference.fullName }}
 				</div>

--- a/app/supportAssignment/services/supportSelectors.js
+++ b/app/supportAssignment/services/supportSelectors.js
@@ -95,6 +95,8 @@ class SupportSelectors {
 						sectionGroup.teachingAssistantAssignmentOptions.other.push(supportStaff);
 					});
 	
+					sectionGroup.teachingAssistantAssignmentOptions.other = _array_sortByProperty(sectionGroup.teachingAssistantAssignmentOptions.other, ["lastName"]);
+
 					// Add readerAssignmentOptions
 					var processedSupportStaffIds = [];
 	
@@ -132,6 +134,7 @@ class SupportSelectors {
 						sectionGroup.readerAssignmentOptions.other.push(supportStaff);
 					});
 	
+
 					// Add instructor preference comment to sectionGroup by following the relationship
 					// sectionGroups -> instructorPreferences -> instructorSupportCallResponses
 					instructorPreferences.ids.forEach(function(preferenceId) {


### PR DESCRIPTION
Important! This PR targets master to ensure the bugfix is deployed immediately after acceptance.

The list displays students by preference rank,
but the section after that should be alphabetize and is instead a random order.
Also fixes a bug where the priority 'badge' was displayed for students without a preference.

Issue:
https://trello.com/c/IQd8FZUP/1864-supportassignments-fix-student-ordering-in-support-assignment-dropdown