### PR TITLE
Fix redirection on access denied

### DIFF
--- a/app/shared/services/AuthService.js
+++ b/app/shared/services/AuthService.js
@@ -30,11 +30,10 @@ class AuthService {
 						localStorage.removeItem('currentUser');
 						$window.location.href = response.data.redirect + "?ref=" + $location.absUrl();
 
-						deferred.resolve();
+						deferred.reject(response);
 					}
 				}, function (error) {
 					var message;
-
 					var jwt = localStorage.getItem('JWT');
 					var loginId = null;
 


### PR DESCRIPTION
The issue was ultimately caused by some very subtle errors caused by a bug in the dependency injection configuration of our httpProvider interceptors.

This then caused the validateToken method to post to the backend, and when the server returned 403 and the 'failure' callback is, a '$q is not defined' error message was taking the place of the server response and status code. Which then meant the rest of the code was unable to identify the 403 and redirection to no-access never happened.

Issue:
https://trello.com/c/6WlH4mcL/1761-ipa-should-properly-handle-users-without-permissions