### PR TITLE
Feature/resize budget columns

### DIFF
--- a/app/budget/directives/lineItems/lineItems.css
+++ b/app/budget/directives/lineItems/lineItems.css
@@ -24,11 +24,19 @@
 	padding-right: 15px;
 }
 
-.line-items__table--amount {
+.line-items__table--type {
 	width: 3%;
 }
 
+.line-items__table--amount {
+	width: 1%;
+}
+
 .line-items__table--checkbox {
+	width: 1%;
+}
+
+.line-items__table--comments {
 	width: 1%;
 }
 

--- a/app/budget/directives/lineItems/lineItems.html
+++ b/app/budget/directives/lineItems/lineItems.html
@@ -76,10 +76,10 @@
 				<!-- Comments -->
 				<td class="line-items__table-cell line-items__table-cell--comments" ng-class-odd="'line-items__table-cell--dark'">
 					<div class="line-items__comment-container">
-						<ipa-button text="'Comments' + lineItem.commentCountDisplay"
+						<ipa-button superscript="lineItem.commentCountDisplay"
+												icon-color="lineItem.commentCountDisplay ? '' : 'gray'"
 						            tooltip-message="'View Comments'"
-						            color="'light'"
-						            icon-class="'entypo entypo-chat'"
+												icon-class="'entypo entypo-chat'"
 						            on-click="openAddLineItemCommentsModal(lineItem)">
 						</ipa-button>
 					</div>

--- a/app/budget/directives/lineItems/lineItems.html
+++ b/app/budget/directives/lineItems/lineItems.html
@@ -10,7 +10,7 @@
 						</ipa-checkbox>
 					</div>
 				</th>
-				<th class="line-items__table-header">
+				<th class="line-items__table-header line-items__table--type">
 					<div class="line-items__table-header-container">
 						Type
 					</div>
@@ -20,7 +20,7 @@
 						Description
 					</div>
 				</th>
-				<th class="line-items__table-header">
+				<th class="line-items__table-header line-items__table--comments">
 					<div class="line-items__table-header-container">
 						Comments
 					</div>

--- a/app/budget/services/actions/budgetCalculations.js
+++ b/app/budget/services/actions/budgetCalculations.js
@@ -466,7 +466,7 @@ class BudgetCalculations {
 					}
 				});
 	
-				lineItem.commentCountDisplay = lineItem.commentCount > 0 ? " (" + lineItem.commentCount + ")" : '';
+				lineItem.commentCountDisplay = lineItem.commentCount > 0 ? lineItem.commentCount : '';
 	
 				// Sort sectionGroupCostComments
 				var reverseOrder = true;

--- a/app/shared/directives/ipaButton/ipaButton.html
+++ b/app/shared/directives/ipaButton/ipaButton.html
@@ -2,6 +2,7 @@
 	uib-tooltip="{{ calculateTooltip() }}"
 	tooltip-placement="bottom"
 	tooltip-append-to-body="true"
+	ng-style="{ color: iconColor ? iconColor : '' }"
 	ng-class="{ buttonClass, 'ipa-button--disabled': isDisabled , 'ipa-button--wide': isWide, 'ipa-button--dark-skin': skin == 'dark', 'ipa-button--light-skin': skin == 'light' || !skin }">
 	<div class="ipa-button__container"
 		ng-class="{'ipa-button__container--wide': isWide }"
@@ -20,6 +21,7 @@
 			</div>
 			<div class="ipa-button__spacer" ng-show="text.length > 0 && iconClass.length > 0"></div>
 			<div ng-class="iconClass"></div>
+			<sup>{{ superscript }}</sup>
 		</div>
 
 		<!-- without confirmation -->
@@ -33,6 +35,7 @@
 		</div>
 		<div class="ipa-button__spacer" ng-show="text.length > 0 && iconClass.length > 0"></div>
 			<div ng-class="iconClass"></div>
+			<sup>{{ superscript }}</sup>
 		</div>
 	</div>
 
@@ -47,6 +50,7 @@
 			</div>
 			<div class="ipa-button__spacer" ng-show="text.length > 0 && iconClass.length > 0"></div>
 			<div ng-class="iconClass"></div>
+			<sup>{{ superscript }}</sup>
 		</div>
 	</div>
 </div>

--- a/app/shared/directives/ipaButton/ipaButton.js
+++ b/app/shared/directives/ipaButton/ipaButton.js
@@ -24,7 +24,9 @@ let ipaButton = function () {
 			size: '<?', // Current options are 'slim', 'short'
 			isWide: '<?', // Boolean: makes button attempt to take 100% width, default is to only take as much width as needed
 			buttonClass: '<?', // Provide additional classes for context specific styling
-			skin: '<?' // Options are 'light' and 'dark' (default light)
+      skin: '<?', // Options are 'light' and 'dark' (default light)
+			superscript: '<?', // Superscript text displayed to the right of the icon
+			iconColor: '<?'  // Accepts optional color value to override default styling
 		},
 		link: function(scope, element, attrs) {
 			scope.calculateTooltip = function() {


### PR DESCRIPTION
Removed redundant text on the Comments button and shrink the column to make room for the Description column. Updated the styling of the button to add color based on existence of comments and move the number to the right of the icon.

Issue: https://trello.com/c/cBkTkgnk/1878-05-budget-description-field-needs-to-be-wider-comments-column-should-be-much-narrower

Before:
![screen shot 2018-08-09 at 12 50 46 pm](https://user-images.githubusercontent.com/13262189/43922210-e5d74e46-9bd2-11e8-8df0-9acb74bdf2c7.png)

After:
![screen shot 2018-08-09 at 12 34 23 pm](https://user-images.githubusercontent.com/13262189/43921838-d80955b2-9bd1-11e8-99dd-df71844effca.png)
