### PR TITLE
Bugfix/support assignments speed

### DIFF
--- a/app/supportAssignment/services/supportReducer.js
+++ b/app/supportAssignment/services/supportReducer.js
@@ -498,9 +498,9 @@ class SupportReducer {
 				// Build new 'page state'
 				// This is the 'view friendly' version of the store
 				let newPageState = {};
-				newPageState.schedule = angular.copy(scope._state.schedule);
-				newPageState.ui = angular.copy(scope._state.ui);
-				newPageState.staffAssignmentOptions = angular.copy(scope._state.staffAssignmentOptions);
+				newPageState.schedule = JSON.parse(JSON.stringify(scope._state.schedule));
+        newPageState.ui = JSON.parse(JSON.stringify(scope._state.ui));
+        newPageState.staffAssignmentOptions = JSON.parse(JSON.stringify(scope._state.staffAssignmentOptions));
 				newPageState.supportAssignmentsUnique = SupportSelectors.generateSupportAssignmentsUnique(scope._state.supportAssignments, scope._state.sectionGroups, scope._state.courses);
 				newPageState.supportAssignments = SupportSelectors.generateSupportAssignments(
 																																				scope._state.supportAssignments,


### PR DESCRIPTION
Replacing `angular.copy()` with `JSON.parse(JSON.stringify(obj))` shaves about 6 seconds off the load time on Firefox 61. There doesn't seem to be any performance implications on Chrome 68. The JSON method should work for deep copying given that the object has no functions or circular references.

Issue: https://trello.com/c/d5BVq1NL/1846-2-supportassignments-changing-ta-count-or-assigning-tas-is-considerably-slower-on-firefox-than-chrome