### PR TITLE
Bugfix/validate char limit

### DIFF
--- a/app/budget/directives/budgetCosts/instructorCostsRow/instructorCostsRow.html
+++ b/app/budget/directives/budgetCosts/instructorCostsRow/instructorCostsRow.html
@@ -59,7 +59,8 @@
 		</div>
 		<div class="instructor-costs__cost-container">
 			<ipa-input value="sectionGroup.sectionGroupCost.reason"
-			           on-update="overrideSectionGroup(sectionGroup, 'reason')">
+			           on-update="overrideSectionGroup(sectionGroup, 'reason')"
+			           max-chars="30">
 			</ipa-input>
 		</div>
 	</td>

--- a/app/budget/directives/modals/addLineItem/addLineItem.html
+++ b/app/budget/directives/modals/addLineItem/addLineItem.html
@@ -42,7 +42,7 @@
 			<div class="col-sm-5">
 				<div class="input-group form-input">
 					<ipa-input value="newLineItem.description"
-					           max-length="100"
+					           max-chars="100"
 					           placeholder="Description">
 					</ipa-input>
 				</div>

--- a/app/budget/directives/modals/addLineItem/addLineItem.html
+++ b/app/budget/directives/modals/addLineItem/addLineItem.html
@@ -41,9 +41,9 @@
 			<label class="col-sm-4 control-label">Description</label>
 			<div class="col-sm-5">
 				<div class="input-group form-input">
-					<ipa-input
-						value="newLineItem.description"
-						placeholder="Description">
+					<ipa-input value="newLineItem.description"
+					           max-length="100"
+					           placeholder="Description">
 					</ipa-input>
 				</div>
 			</div>

--- a/app/shared/directives/ipaInput/ipaInput.html
+++ b/app/shared/directives/ipaInput/ipaInput.html
@@ -7,6 +7,7 @@
 		placeholder="{{placeHolder}}"
 		ng-readonly="readOnly || labelReadOnly"
 		ng-keyup="updateInput()"
+		maxlength="{{maxChars}}"
 		ng-class="{'ipa-input--read-only': readOnly, 'ipa-input--label-read-only': labelReadOnly, 'ipa-input--invalid': isInvalid }">
 
 	<input class="ipa-input"
@@ -17,5 +18,6 @@
 		placeholder="{{placeHolder}}"
 		ng-readonly="readOnly || labelReadOnly"
 		ng-keyup="updateInput()"
+		maxlength="{{maxChars}}"
 		ng-class="{'ipa-input--read-only': readOnly, 'ipa-input--label-read-only': labelReadOnly }">
 </div>

--- a/app/shared/directives/ipaInput/ipaInput.js
+++ b/app/shared/directives/ipaInput/ipaInput.js
@@ -11,7 +11,8 @@ let ipaInput = function ($timeout) {
 			placeHolder: '<?', // Default text when empty
 			updateDelay: '<?', // If an update function has been specified it will default to 500ms delay, can override that here
 			isInvalid: '<?',
-			mode: '<?' // Options are 'number' (only allow characters 0-9), and 'currency' (currency style formatting and input enforcement)
+			mode: '<?', // Options are 'number' (only allow characters 0-9), and 'currency' (currency style formatting and input enforcement)
+			maxChars: '<?'
 		},
 		link: function(scope, element, attrs) {
 			scope.$watch('mode',function() {


### PR DESCRIPTION
Updates the budget UI to stop users from adding more characters than than the backend supports for SectionGroupCost.reason and LineItem.description

Issue:
https://trello.com/c/abGWO6o0/1896-1-budgetview-ui-does-not-enforce-varchar30-limit-on-sectiongroupcost-reason-field

https://trello.com/c/lJZvZRkT/1895-1-budgetview-ui-does-not-enforce-varchar100-limit-on-the-lineitem-description-field