### PR TITLE
Updating character limits on lineItem notes and description

### DIFF
--- a/app/budget/directives/modals/addCourseComments/addCourseComments.html
+++ b/app/budget/directives/modals/addCourseComments/addCourseComments.html
@@ -23,8 +23,6 @@
 				({{ dateToRelative(comment.lastModifiedOn) }})
 			</span>
 		</div>
-		<div class="comment-body">
-			{{ comment.comment }}
-		</div>
+		<div class="comment-body">{{ comment.comment }}</div>
 	</div>
 </div>

--- a/app/budget/directives/modals/addLineItem/addLineItem.css
+++ b/app/budget/directives/modals/addLineItem/addLineItem.css
@@ -50,3 +50,9 @@
 .add-line-item .form-input {
 	width: 100%;
 }
+
+.add-line-item__notes {
+	resize: none;
+	border-color: #e2e2e2;
+	width: 100%;
+}

--- a/app/budget/directives/modals/addLineItem/addLineItem.html
+++ b/app/budget/directives/modals/addLineItem/addLineItem.html
@@ -42,7 +42,7 @@
 			<div class="col-sm-5">
 				<div class="input-group form-input">
 					<ipa-input value="newLineItem.description"
-					           max-chars="100"
+					           max-chars="500"
 					           placeholder="Description">
 					</ipa-input>
 				</div>
@@ -53,10 +53,7 @@
 			<label class="col-sm-4 control-label">Notes</label>
 			<div class="col-sm-5">
 				<div class="input-group form-input">
-					<ipa-input
-						value="newLineItem.notes"
-						placeholder="Notes">
-					</ipa-input>
+					<textarea placeholder="Add a note" rows="3" class="add-line-item__notes" ng-model="newLineItem.notes"></textarea>
 				</div>
 			</div>
 		</div>

--- a/app/budget/directives/modals/addLineItem/addLineItem.html
+++ b/app/budget/directives/modals/addLineItem/addLineItem.html
@@ -53,7 +53,7 @@
 			<label class="col-sm-4 control-label">Notes</label>
 			<div class="col-sm-5">
 				<div class="input-group form-input">
-					<textarea placeholder="Add a note" rows="3" class="add-line-item__notes" ng-model="newLineItem.notes"></textarea>
+					<textarea placeholder="Add a note" rows="3" maxlength="750" class="add-line-item__notes" ng-model="newLineItem.notes"></textarea>
 				</div>
 			</div>
 		</div>

--- a/app/budget/directives/modals/addLineItemComments/addLineItemComments.html
+++ b/app/budget/directives/modals/addLineItemComments/addLineItemComments.html
@@ -30,8 +30,6 @@
 				({{ dateToRelative(comment.lastModifiedOn) }})
 			</span>
 		</div>
-		<div class="comment-body">
-			{{ comment.comment }}
-		</div>
+		<div class="comment-body">{{ comment.comment }}</div>
 	</div>
 </div>


### PR DESCRIPTION
Issue:
https://trello.com/c/lJZvZRkT/1895-1-budgetview-ui-does-not-enforce-varchar100-limit-on-the-lineitem-description-field