### PR TITLE
Budget: Should alphabetize instructors in instructor assignment dropdown

### DIFF
--- a/app/budget/services/actions/budgetCalculations.js
+++ b/app/budget/services/actions/budgetCalculations.js
@@ -280,8 +280,9 @@ class BudgetCalculations {
 					calculatedInstructors.push(self._generateInstructor(instructorId));
 					usedInstructorIds.push(instructorId);
 				});
-	
-				calculatedInstructors = _array_sortByProperty(calculatedInstructors, ["instructorTypeDescription", "lastName"]);
+
+				calculatedInstructors = _array_sortByProperty(calculatedInstructors, ["lastName"]);
+				calculatedActiveInstructors = _array_sortByProperty(calculatedActiveInstructors, ["lastName"]);
 
 				let instructorAssignmentOptions = [];
 	


### PR DESCRIPTION
Issue:
https://trello.com/c/FNz5JsXP/1899-05-budget-view-schedule-costs-instructor-dropdown-should-be-in-abc-order