### PR TITLE
ScheduleView: Display CRN in activity list

### DIFF
--- a/app/scheduling/templates/SchedulingCtrl.html
+++ b/app/scheduling/templates/SchedulingCtrl.html
@@ -192,7 +192,6 @@
 						<spinner></spinner>
 					</div>
 					<div ng-show="view.state.sectionGroups.list[view.state.uiState.selectedSectionGroupId].sectionIds">
-
 						<p class="activity-list-header">
 							{{ view.state.courses.list[view.state.uiState.selectedCourseId].subjectCode }} {{ view.state.courses.list[view.state.uiState.selectedCourseId].courseNumber
 							}} - {{ view.state.courses.list[view.state.uiState.selectedCourseId].sequencePattern }}
@@ -207,6 +206,7 @@
 							<div class="section-pattern section-is-numeric" ng-hide="view.state.courses.list[view.state.uiState.selectedCourseId].isSeries()">
 								<div class="section-label">
 									Section {{ view.state.courses.list[view.state.uiState.selectedCourseId].sequencePattern }}
+									(CRN: {{view.state.sections.list[view.state.sectionGroups.list[view.state.uiState.selectedSectionGroupId].sectionIds[0]].crn}})
 								</div>
 								<div class="delete-section-ui"
 									ng-init="sectionId = view.state.sectionGroups.list[view.state.uiState.selectedSectionGroupId].sectionIds[0]">
@@ -249,7 +249,7 @@
 										ng-init="section = view.state.sections.list[sectionId];">
 									<div class="section-pattern section-in-series">
 										<div class="section-label">
-											Section {{ view.state.sections.list[sectionId].sequenceNumber }}
+											Section {{ view.state.sections.list[sectionId].sequenceNumber }} (CRN: {{view.state.sections.list[sectionId].crn}})
 										</div>
 										<div class="delete-section-ui">
 											<i class="entypo-minus-squared delete-section-ui clickable" uib-tooltip="Remove section {{ section.sequenceNumber }}"


### PR DESCRIPTION
Adds CRN next to Section number

![screenshot-localhost-9000-2018 09 05-09-22-42](https://user-images.githubusercontent.com/13262189/45107088-56838e00-b0ed-11e8-8b73-a213cf0c0308.png)

Issue:
https://trello.com/c/fuL12ZCC/1800-schedulingview-show-crns-on-the-section-if-available
https://trello.com/c/JV6PD2bb/1803-ability-to-see-crns-somewhere-doesnt-have-to-be-on-the-calendar