### PR TITLE
ScheduleSummaryReport: Show instructor type next to instructor name

### DIFF
--- a/app/scheduleSummaryReport/services/scheduleSummaryReportStateService.js
+++ b/app/scheduleSummaryReport/services/scheduleSummaryReportStateService.js
@@ -102,8 +102,7 @@ class ScheduleSummaryReportStateService {
 								var slotInstructor = instructors.list[slotTeachingAssignment.instructorId];
 								var slotInstructorType = instructorTypes.list[slotTeachingAssignment.instructorTypeId];
 								var instructorName = TeachingAssignmentService.getInstructorDescription(slotTeachingAssignment, slotInstructor, slotInstructorType);
-
-								slotSectionGroup.instructors.push(instructorName);
+								slotSectionGroup.instructors.push({instructorName: instructorName, instructorType: slotInstructorType.description});
 							}
 						});
 

--- a/app/scheduleSummaryReport/templates/ScheduleSummaryReportCtrl.html
+++ b/app/scheduleSummaryReport/templates/ScheduleSummaryReportCtrl.html
@@ -83,7 +83,8 @@
 										</span>
 										<div ng-repeat="instructor in sectionGroup.instructors"
 										     class="section-diff-element section-instructors">
-											{{ instructor }}<span ng-if="$last == false">, </span>
+											{{ instructor.instructorName }} ({{ instructor.instructorType }})
+											<span ng-if="$last == false">, </span>
 										</div>
 									</div>
 									<div class="section-group__teaching-assistants">

--- a/app/scheduleSummaryReport/templates/ScheduleSummaryReportCtrl.html
+++ b/app/scheduleSummaryReport/templates/ScheduleSummaryReportCtrl.html
@@ -82,8 +82,8 @@
 												Instructors: 
 										</span>
 										<div ng-repeat="instructor in sectionGroup.instructors"
-										     class="section-diff-element section-instructors">
-											{{ instructor.instructorName }}
+												 class="section-diff-element section-instructors">
+											{{ instructor.instructorName === instructor.instructorType ? "Unassigned" : instructor.instructorName }}
 											({{ instructor.instructorType }})<span ng-if="$last == false">, </span>
 										</div>
 									</div>

--- a/app/scheduleSummaryReport/templates/ScheduleSummaryReportCtrl.html
+++ b/app/scheduleSummaryReport/templates/ScheduleSummaryReportCtrl.html
@@ -83,8 +83,8 @@
 										</span>
 										<div ng-repeat="instructor in sectionGroup.instructors"
 										     class="section-diff-element section-instructors">
-											{{ instructor.instructorName }} ({{ instructor.instructorType }})
-											<span ng-if="$last == false">, </span>
+											{{ instructor.instructorName }}
+											({{ instructor.instructorType }})<span ng-if="$last == false">, </span>
 										</div>
 									</div>
 									<div class="section-group__teaching-assistants">


### PR DESCRIPTION
![screen shot 2018-09-05 at 9 29 05 am](https://user-images.githubusercontent.com/13262189/45107357-2be60500-b0ee-11e8-9f03-d5620dd2ec11.png)


Issue:
https://trello.com/c/ifpdQBHR/1764-schedulesummaryreport-add-instructor-type-next-to-instructor-name