### PR TITLE
Show checkmark next to current value in switcher

### DIFF
--- a/app/shared/directives/ipaTermSelectorDropdown/ipaTermSelectorDropdown.html
+++ b/app/shared/directives/ipaTermSelectorDropdown/ipaTermSelectorDropdown.html
@@ -22,6 +22,7 @@
 			class="dropdown-menu" style="width: 250px;" aria-labelledby="dropdownMenu1">
 		<li ng-repeat="term in scheduleTerms" style="cursor: pointer;">
 			<a ng-click="gotoTerm(term.shortCode)">
+				<i class="entypo-check" ng-class="{'invisible': term.shortCode !== termShortCode}"></i>
 				{{ term.description }}
 			</a>
 		</li>


### PR DESCRIPTION
![screen shot 2018-09-05 at 10 00 37 am](https://user-images.githubusercontent.com/13262189/45108856-b6306800-b0f2-11e8-8eb7-4d4594c3bc25.png)

Issue:
https://trello.com/c/25Mpxk34/1914-site-wide-workgroup-switcher-and-term-switcher-should-have-check-marks-in-the-dropdown-indicating-what-the-current-value-is