### PR TITLE
Make preference dropdown menu wider.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ ipa-ucdavis-edu.env
 cypress.env.json
 cypress/videos
 cypress/screenshots
+yarn-error.log

--- a/app/teachingCall/css/teaching-call-form.css
+++ b/app/teachingCall/css/teaching-call-form.css
@@ -886,7 +886,8 @@ li.active-term .dropdown-term-row {
 }
 
 .search-course-container .dropdown-menu {
-	width: 26%;
+	min-width: 26%;
+	width: auto!important;
 }
 
 #modal-1 {

--- a/app/teachingCall/css/teaching-call-form.css
+++ b/app/teachingCall/css/teaching-call-form.css
@@ -887,7 +887,7 @@ li.active-term .dropdown-term-row {
 
 .search-course-container .dropdown-menu {
 	min-width: 26%;
-	width: auto!important;
+	width: auto;
 }
 
 #modal-1 {


### PR DESCRIPTION

<img src="https://user-images.githubusercontent.com/35669433/45513493-a7cbf700-b757-11e8-96d1-dfc9933f09a4.png"  width="250" height="320">

Issue: https://trello.com/c/Ixs8DjhK/1881-05-teaching-call-instructor-form-preference-dropdown-should-be-wider