### PR TITLE
Bugfix: Cost should update when overriding implied value

### DIFF
--- a/app/budget/directives/budgetCosts/instructorCostsRow/instructorCostsRow.html
+++ b/app/budget/directives/budgetCosts/instructorCostsRow/instructorCostsRow.html
@@ -83,7 +83,7 @@
 				<ipa-input mode="'currency'"
 				           place-holder="'$' + (sectionGroup.overrideInstructorCost || 0)"
 				           value="sectionGroup.newInstructorCost"
-				           on-update="updateInstructorCost(sectionGroup.sectionGroupCost, sectionGroup.newInstructorCost)">
+				           on-update="updateInstructorCost(sectionGroup, sectionGroup.newInstructorCost)">
 				</ipa-input>
 			</div>
 		</div>

--- a/app/budget/directives/budgetCosts/instructorCostsRow/instructorCostsRow.js
+++ b/app/budget/directives/budgetCosts/instructorCostsRow/instructorCostsRow.js
@@ -32,6 +32,9 @@ let instructorCostsRow = function ($rootScope, BudgetActions) {
 			};
 
 			scope.updateInstructorCost = function(sectionGroup, overrideInstructorCost) {
+				if (overrideInstructorCost) {
+					sectionGroup.overrideInstructorCost = parseFloat(overrideInstructorCost);
+				}
 				sectionGroup.cost = angular.copy(parseFloat(sectionGroup.overrideInstructorCost));
 
 				scope.overrideSectionGroup(sectionGroup, 'instructorCost');


### PR DESCRIPTION
This bugfix targets the Master branch. This bug may not exist on the updated budgetView branch.

On the BudgetView Schedule Cost tab, updating a instructor cost with an implied value will throw a JS TypeError or simply not update the value. Reloading the page will display old implied value rather than the user input.

Expected behavior:
Show the implied value if it exists. Override the implied value with the user input if supplied. If user removes the supplied value, it should display the implied value again.

Issue: https://trello.com/c/nTAM9KAG/1925-budgetview-schedule-costs-error