### PR TITLE
BudgetView: Darken font color of instructor cost

### DIFF
--- a/app/budget/directives/budgetCosts/instructorCostsRow/instructorCostsRow.css
+++ b/app/budget/directives/budgetCosts/instructorCostsRow/instructorCostsRow.css
@@ -26,6 +26,15 @@
 	padding-right: 20px;
 }
 
+.instructor-costs__cost-container input::placeholder{
+	color: #5f6368;
+}
+
+/* MS Edge Support */
+.instructor-costs__cost-container input::-webkit-input-placeholder {
+	color: #5f6368;
+}
+
 .instructor-costs__cell-container {
 	display: flex;
 	align-items: center;


### PR DESCRIPTION
Before: 
![current color](https://user-images.githubusercontent.com/13262189/45505726-2cac1600-b742-11e8-9a63-b0133597de3b.png)

After:
![updated color](https://user-images.githubusercontent.com/13262189/45505732-32096080-b742-11e8-8028-c3f46b42e147.png)

Issue: https://trello.com/c/AB3An6cm/1763-budgetview-instructor-cost-font-color-is-too-hard-to-read