### PR TITLE
Bugfix/Do not assume loginId is set

### DIFF
--- a/app/workloadSummaryReport/services/workloadSummaryActions.js
+++ b/app/workloadSummaryReport/services/workloadSummaryActions.js
@@ -171,7 +171,7 @@ class WorkloadSummaryActions {
 					};
 
 					rawInstructors.forEach(function(instructor) {
-						instructor.loginId = instructor.loginId.toLowerCase();
+						instructor.loginId = instructor.loginId ? instructor.loginId.toLowerCase() : null;
 						instructors.ids.push(instructor.id);
 						instructors.list[instructor.id] = instructor;
 					});


### PR DESCRIPTION
Fixes issue in workload summary report.

Issue:
https://trello.com/c/fOJranMS/1951-js-exception-cannot-read-property-tolowercase-of-null