### PR TITLE
Bugfix/Fix associate instructor assignment

### DIFF
--- a/app/assignment/services/assignmentStateService.js
+++ b/app/assignment/services/assignmentStateService.js
@@ -437,7 +437,7 @@ class AssignmentStateService {
 							// Scaffold all teachingAssignment termCodeId arrays
 							var allTerms = ['01', '02', '03', '04', '06', '07', '08', '09', '10'];
 							allTerms.forEach(function (slotTerm) {
-								var generatedTermCode = generateTermCode(action.payload.year, slotTerm);
+								var generatedTermCode = _self.generateTermCode(action.payload.year, slotTerm);
 								instructor.teachingAssignmentTermCodeIds[generatedTermCode] = [];
 							});
 	


### PR DESCRIPTION
There was a javascript bug that caused the UI to fail to update properly after assigning a specific associate instructor into a teaching assignment for a course.

Issue:
https://trello.com/c/3NPdJvCd/1953-05-assignmentsview-generatetermcode-is-not-defined