### PR TITLE
BudgetView: Fix bug in add course logic

### DIFF
--- a/app/budget/services/actions/budgetActions.js
+++ b/app/budget/services/actions/budgetActions.js
@@ -259,6 +259,7 @@ class BudgetActions {
 				let term = BudgetReducers._state.ui.termNav.activeTerm;
 				let year = BudgetReducers._state.ui.year;
 
+				// When SectionGroupCost is not associated with a scheduled course, it will already have its effectiveTermCode
 				if (!sectionGroupCost.effectiveTermCode) {
 					var sectionGroup = BudgetReducers._state.sectionGroups.list[sectionGroupCost.sectionGroupId];
 					var course = BudgetReducers._state.courses.list[sectionGroup.courseId];

--- a/app/budget/services/actions/budgetActions.js
+++ b/app/budget/services/actions/budgetActions.js
@@ -258,12 +258,15 @@ class BudgetActions {
 
 				let term = BudgetReducers._state.ui.termNav.activeTerm;
 				let year = BudgetReducers._state.ui.year;
-				var sectionGroup = BudgetReducers._state.sectionGroups.list[sectionGroupCost.sectionGroupId];
-				var course = BudgetReducers._state.courses.list[sectionGroup.courseId];
+
+				if (!sectionGroupCost.effectiveTermCode) {
+					var sectionGroup = BudgetReducers._state.sectionGroups.list[sectionGroupCost.sectionGroupId];
+					var course = BudgetReducers._state.courses.list[sectionGroup.courseId];
+					sectionGroupCost.effectiveTermCode = course.effectiveTermCode;
+				}
 
 				sectionGroupCost.termCode = TermService.termToTermCode(term, year);
 				sectionGroupCost.budgetScenarioId = BudgetReducers._state.ui.selectedBudgetScenarioId;
-				sectionGroupCost.effectiveTermCode = course.effectiveTermCode;
 
 				BudgetService.createSectionGroupCost(sectionGroupCost).then(function (newSectionGroupCost) {
 					var action = {


### PR DESCRIPTION
Targets master for quick deploy as the bug is fairly serious.

Issue:
https://trello.com/c/pOZQWMnU/1976-budgetview-ui-error-when-attempting-to-add-a-new-course-to-a-scenario