### PR TITLE
BudgetComparison: NaN is sometimes displayed on course cost change percentage 

### DIFF
--- a/app/reports/budgetComparison/services/budgetComparisonReportCalculations.js
+++ b/app/reports/budgetComparison/services/budgetComparisonReportCalculations.js
@@ -130,7 +130,7 @@ class BudgetComparisonReportCalculations {
 				// If an instructorType is set
 				} else if (sectionGroupCost.instructorTypeId) {
 					var instructorTypeCostId = instructorTypeCosts.byInstructorTypeId[sectionGroupCost.instructorTypeId];
-					instructorTypeCost = instructorTypeCosts.list[instructorTypeCostId];
+					instructorTypeCost = instructorTypeCosts.list[instructorTypeCostId] ? instructorTypeCosts.list[instructorTypeCostId].cost : null;
 					instructorTypeId = sectionGroupCost.instructorTypeId;
 				// If there is an assignment
 				} else if (teachingAssignment) {


### PR DESCRIPTION
For instructorTypeCosts, it should pass the cost property, not the root object.

Issue:
https://trello.com/c/aCa4KLkL/1989-budgetcomparison-nan-in-some-columns-for-change-percentage#