### PR TITLE
Bugfix/teaching call no course warning

### DIFF
--- a/app/teachingCall/teachingCallStatus/controllers/TeachingCallStatusCtrl.js
+++ b/app/teachingCall/teachingCallStatus/controllers/TeachingCallStatusCtrl.js
@@ -1,7 +1,7 @@
 import 'TeachingCall/css/teaching-call-status.css';
 
 class TeachingCallStatusCtrl {
-	constructor ($scope, $rootScope, $window, $route, $routeParams, TeachingCallStatusActionCreators, TeachingCallStatusService, CourseService, AuthService) {
+	constructor ($scope, $rootScope, $window, $route, $routeParams, TeachingCallStatusActionCreators, TeachingCallStatusService, AuthService) {
 		this.AuthService = AuthService;
 		this.$rootScope = $rootScope;
 		this.$window = $window;
@@ -9,7 +9,6 @@ class TeachingCallStatusCtrl {
 		this.$routeParams = $routeParams;
 		this.TeachingCallStatusActionCreators = TeachingCallStatusActionCreators;
 		this.TeachingCallStatusService = TeachingCallStatusService;
-		this.CourseService = CourseService;
 		this.AuthService = AuthService;
 
 		$scope.modalStyles = { "width" : "75%" };
@@ -68,11 +67,6 @@ class TeachingCallStatusCtrl {
 
 		// Launches Call Instructor Modal
 		$scope.openAddInstructorsModal = function() {
-			CourseService.getScheduleByWorkgroupIdAndYear($scope.workgroupId, $scope.year)
-				.then(function (res) {
-					$scope.view.state.scheduleHasCourses = (res.courses.length !== 0);
-				});
-
 			$scope.view.state.openCallInstructorModal = true;
 		};
 
@@ -82,6 +76,6 @@ class TeachingCallStatusCtrl {
 	}
 }
 
-TeachingCallStatusCtrl.$inject = ['$scope', '$rootScope', '$window', '$route', '$routeParams', 'TeachingCallStatusActionCreators', 'TeachingCallStatusService', 'CourseService', 'AuthService'];
+TeachingCallStatusCtrl.$inject = ['$scope', '$rootScope', '$window', '$route', '$routeParams', 'TeachingCallStatusActionCreators', 'TeachingCallStatusService', 'AuthService'];
 
 export default TeachingCallStatusCtrl;

--- a/app/teachingCall/teachingCallStatus/controllers/TeachingCallStatusCtrl.js
+++ b/app/teachingCall/teachingCallStatus/controllers/TeachingCallStatusCtrl.js
@@ -25,11 +25,6 @@ class TeachingCallStatusCtrl {
 
 		$rootScope.$on('teachingCallStatusStateChanged', function (event, data) {
 			$scope.view.state = data;
-
-			CourseService.getScheduleByWorkgroupIdAndYear($scope.workgroupId, $scope.year)
-				.then(function (res) {
-					$scope.view.state.scheduleHasCourses = (res.courses.length !== 0);
-				});
 		});
 
 		$scope.toggleInstructor = function(instructor) {
@@ -73,6 +68,11 @@ class TeachingCallStatusCtrl {
 
 		// Launches Call Instructor Modal
 		$scope.openAddInstructorsModal = function() {
+			CourseService.getScheduleByWorkgroupIdAndYear($scope.workgroupId, $scope.year)
+				.then(function (res) {
+					$scope.view.state.scheduleHasCourses = (res.courses.length !== 0);
+				});
+
 			$scope.view.state.openCallInstructorModal = true;
 		};
 

--- a/app/teachingCall/teachingCallStatus/controllers/TeachingCallStatusCtrl.js
+++ b/app/teachingCall/teachingCallStatus/controllers/TeachingCallStatusCtrl.js
@@ -28,7 +28,7 @@ class TeachingCallStatusCtrl {
 
 			CourseService.getScheduleByWorkgroupIdAndYear($scope.workgroupId, $scope.year)
 				.then(function (res) {
-					$scope.view.state.scheduleHasCourses = (res.courses.length === 0);
+					$scope.view.state.scheduleHasCourses = (res.courses.length !== 0);
 				});
 		});
 

--- a/app/teachingCall/teachingCallStatus/directives/modals/addInstructorsModal/addInstructorsModal.html
+++ b/app/teachingCall/teachingCallStatus/directives/modals/addInstructorsModal/addInstructorsModal.html
@@ -114,20 +114,20 @@
 
   <div class="add-instructors-modal__footer">
     <!-- send buttons -->
-    <button ng-if="startTeachingCallConfig.isAddInstructorFormComplete == true && startTeachingCallConfig.sendEmail && state.scheduleHasCourses === true"
+    <button ng-if="startTeachingCallConfig.isAddInstructorFormComplete == true && startTeachingCallConfig.sendEmail && state.ui.scheduleHasCourses === true"
             type="button"
             class="btn neon-dark-confirm-btn"
             ng-click="submit()">
       Send
     </button>
-    <button ng-if="startTeachingCallConfig.isAddInstructorFormComplete == false && startTeachingCallConfig.sendEmail && state.scheduleHasCourses === true"
+    <button ng-if="startTeachingCallConfig.isAddInstructorFormComplete == false && startTeachingCallConfig.sendEmail && state.ui.scheduleHasCourses === true"
             tooltip-placement="left"
             uib-tooltip="You must select at least one term and one instructor"
             type="button"
             class="disabled btn btn-info neon-dark-confirm-btn">
       Send
     </button>
-    <button ng-if="startTeachingCallConfig.sendEmail && state.scheduleHasCourses === false"
+    <button ng-if="startTeachingCallConfig.sendEmail && state.ui.scheduleHasCourses === false"
             tooltip-placement="left"
             uib-tooltip="You have no courses scheduled for the year"
             type="button"
@@ -136,20 +136,20 @@
     </button>
 
     <!-- start buttons (no email) -->
-    <button ng-if="startTeachingCallConfig.isAddInstructorFormComplete == true && !startTeachingCallConfig.sendEmail && state.scheduleHasCourses === true"
+    <button ng-if="startTeachingCallConfig.isAddInstructorFormComplete == true && !startTeachingCallConfig.sendEmail && state.ui.scheduleHasCourses === true"
             type="button"
             class="btn neon-dark-confirm-btn"
             ng-click="submit()">
       Start
     </button>
-    <button ng-if="startTeachingCallConfig.isAddInstructorFormComplete == false && !startTeachingCallConfig.sendEmail && state.scheduleHasCourses === true"
+    <button ng-if="startTeachingCallConfig.isAddInstructorFormComplete == false && !startTeachingCallConfig.sendEmail && state.ui.scheduleHasCourses === true"
             tooltip-placement="left"
             uib-tooltip="You must select at least one term and one instructor"
             type="button"
             class="disabled btn btn-info neon-dark-confirm-btn">
       Start
     </button>
-    <button ng-if="!startTeachingCallConfig.sendEmail && state.scheduleHasCourses === false"
+    <button ng-if="!startTeachingCallConfig.sendEmail && state.ui.scheduleHasCourses === false"
             tooltip-placement="left"
             uib-tooltip="You have no courses scheduled for the year"
             type="button"

--- a/app/teachingCall/teachingCallStatus/directives/modals/addInstructorsModal/addInstructorsModal.html
+++ b/app/teachingCall/teachingCallStatus/directives/modals/addInstructorsModal/addInstructorsModal.html
@@ -151,7 +151,7 @@
     </button>
     <button ng-if="!startTeachingCallConfig.sendEmail && state.scheduleHasCourses === false"
             tooltip-placement="left"
-            uib-tooltip="You must select at least one term and one instructor"
+            uib-tooltip="You have no courses scheduled for the year"
             type="button"
             class="disabled btn btn-info neon-dark-confirm-btn">
       Start

--- a/app/teachingCall/teachingCallStatus/directives/modals/addInstructorsModal/addInstructorsModal.html
+++ b/app/teachingCall/teachingCallStatus/directives/modals/addInstructorsModal/addInstructorsModal.html
@@ -114,20 +114,20 @@
 
   <div class="add-instructors-modal__footer">
     <!-- send buttons -->
-    <button ng-if="startTeachingCallConfig.isAddInstructorFormComplete == true && startTeachingCallConfig.sendEmail && state.scheduleHasCourses === false"
+    <button ng-if="startTeachingCallConfig.isAddInstructorFormComplete == true && startTeachingCallConfig.sendEmail && state.scheduleHasCourses === true"
             type="button"
             class="btn neon-dark-confirm-btn"
             ng-click="submit()">
       Send
     </button>
-    <button ng-if="startTeachingCallConfig.isAddInstructorFormComplete == false && startTeachingCallConfig.sendEmail && state.scheduleHasCourses === false"
+    <button ng-if="startTeachingCallConfig.isAddInstructorFormComplete == false && startTeachingCallConfig.sendEmail && state.scheduleHasCourses === true"
             tooltip-placement="left"
             uib-tooltip="You must select at least one term and one instructor"
             type="button"
             class="disabled btn btn-info neon-dark-confirm-btn">
       Send
     </button>
-    <button ng-if="startTeachingCallConfig.sendEmail && state.scheduleHasCourses === true"
+    <button ng-if="startTeachingCallConfig.sendEmail && state.scheduleHasCourses === false"
             tooltip-placement="left"
             uib-tooltip="You have no courses scheduled for the year"
             type="button"
@@ -136,20 +136,20 @@
     </button>
 
     <!-- start buttons (no email) -->
-    <button ng-if="startTeachingCallConfig.isAddInstructorFormComplete == true && !startTeachingCallConfig.sendEmail && state.scheduleHasCourses === false"
+    <button ng-if="startTeachingCallConfig.isAddInstructorFormComplete == true && !startTeachingCallConfig.sendEmail && state.scheduleHasCourses === true"
             type="button"
             class="btn neon-dark-confirm-btn"
             ng-click="submit()">
       Start
     </button>
-    <button ng-if="startTeachingCallConfig.isAddInstructorFormComplete == false && !startTeachingCallConfig.sendEmail && state.scheduleHasCourses === false"
+    <button ng-if="startTeachingCallConfig.isAddInstructorFormComplete == false && !startTeachingCallConfig.sendEmail && state.scheduleHasCourses === true"
             tooltip-placement="left"
             uib-tooltip="You must select at least one term and one instructor"
             type="button"
             class="disabled btn btn-info neon-dark-confirm-btn">
       Start
     </button>
-    <button ng-if="!startTeachingCallConfig.sendEmail && state.scheduleHasCourses === true"
+    <button ng-if="!startTeachingCallConfig.sendEmail && state.scheduleHasCourses === false"
             tooltip-placement="left"
             uib-tooltip="You must select at least one term and one instructor"
             type="button"

--- a/app/teachingCall/teachingCallStatus/services/teachingCallStatusActionCreators.js
+++ b/app/teachingCall/teachingCallStatus/services/teachingCallStatusActionCreators.js
@@ -1,24 +1,29 @@
 class TeachingCallStatusActionCreators {
-	constructor (TeachingCallStatusStateService, TeachingCallStatusService, $rootScope, $window, Role, ActionTypes, $route) {
+	constructor (TeachingCallStatusStateService, TeachingCallStatusService, CourseService, $rootScope, $window, Role, ActionTypes, $route) {
 		return {
 			getInitialState: function (tab) {
 				var self = this;
 				var workgroupId = $route.current.params.workgroupId;
 				var year = $route.current.params.year;
 
-				TeachingCallStatusService.getInitialState(workgroupId, year).then(function (payload) {
-					var action = {
-						type: ActionTypes.INIT_STATE,
-						payload: payload,
-						year: year,
-						tab: tab
-					};
-					TeachingCallStatusStateService.reduce(action);
-					self._calculateInstructorsInCall();
-					self._calculateEligibleInstructors();
-					self._calculatePendingEmails();
-				}, function (err) {
-					$rootScope.$emit('toast', { message: "Could not load initial teaching call status state.", type: "ERROR" });
+				CourseService.getScheduleByWorkgroupIdAndYear(workgroupId, year).then(function (res) {
+					var scheduleHasCourses = res.courses.length !== 0;
+
+					TeachingCallStatusService.getInitialState(workgroupId, year).then(function (payload) {
+						var action = {
+							type: ActionTypes.INIT_STATE,
+							payload: payload,
+							year: year,
+							tab: tab,
+							scheduleHasCourses: scheduleHasCourses
+						};
+						TeachingCallStatusStateService.reduce(action);
+						self._calculateInstructorsInCall();
+						self._calculateEligibleInstructors();
+						self._calculatePendingEmails();
+					}, function (err) {
+						$rootScope.$emit('toast', { message: "Could not load initial teaching call status state.", type: "ERROR" });
+					});
 				});
 			},
 			contactInstructors: function (workgroupId, year, teachingCallConfig, selectedInstructors) {

--- a/app/teachingCall/teachingCallStatus/services/teachingCallStatusStateService.js
+++ b/app/teachingCall/teachingCallStatus/services/teachingCallStatusStateService.js
@@ -66,7 +66,8 @@ class TeachingCallStatusStateService {
 						var ui = {
 							selectedInstructorIds: [],
 							instructorsInCalls: false,
-							haveUnsentEmails: false
+							haveUnsentEmails: false,
+							scheduleHasCourses: action.scheduleHasCourses
 						};
 						return ui;
 					case ActionTypes.CALCULATE_PENDING_EMAILS:


### PR DESCRIPTION
Issue: https://trello.com/c/yFWMelYH/1994-it-is-still-possible-to-create-a-teaching-call-if-you-have-no-courses

There was a bug where the logic wasn't properly updated after renaming the variable from `isCourseTableEmpty` to `scheduleHasCourses` in #1587. There was also an issue where the check for scheduled courses ran multiple times on `teachingCallStatusStateChanged` that led to an inconsistent value. The check is now in the initial state and only runs once on state change.