### PR TITLE
Bugfix/teaching call dropdown highlight

### DIFF
--- a/app/teachingCall/teachingCallForm/controllers/TeachingCallFormCtrl.js
+++ b/app/teachingCall/teachingCallForm/controllers/TeachingCallFormCtrl.js
@@ -67,12 +67,8 @@ class TeachingCallFormCtrl {
 				}
 			});
 
-			var results = [];
-			if (!query || query.length == 0) {
-				results = angular.copy(uniquePreferenceOptions);
-			}
-
-			if (query.length >= 3) {
+			var results = angular.copy(uniquePreferenceOptions);
+			if (query) {
 				var options = {
 					shouldSort: true,
 					threshold: 0.8,

--- a/app/teachingCall/teachingCallForm/controllers/TeachingCallFormCtrl.js
+++ b/app/teachingCall/teachingCallForm/controllers/TeachingCallFormCtrl.js
@@ -74,6 +74,10 @@ class TeachingCallFormCtrl {
 					.groupBy(function(course) { return course.subjectCode; })
 					.map(function(groupedCourses) { groupedCourses[0].firstInGroup = true; return groupedCourses; }).flatten().value();
 				groupedResults.push({ description: "Suggest a Course ...", suggestACourse: true });
+				groupedResults.unshift({ description: "Non-Courses", header: true });
+				var firstCourseIndex = groupedResults.findIndex(function (result) { return result.uniqueIdentifier; });
+				var firstSubjectCode = groupedResults[firstCourseIndex].subjectCode;
+				groupedResults.splice(firstCourseIndex, 0, { description: firstSubjectCode + " Courses", header: true });
 				return groupedResults;
 			}
 
@@ -101,7 +105,17 @@ class TeachingCallFormCtrl {
 					.groupBy(function(result) { return result.subjectCode; })
 					.map(function(groupedCourses) { groupedCourses[0].firstInGroup = true; return groupedCourses; }).flatten().value();
 
-				// Append Suggest a Course option
+				// Inject group headers
+				var firstDescription = groupedResults[0].uniqueIdentifier ? groupedResults[0].subjectCode + " Courses" : "Non-Courses";
+				groupedResults[0].firstInGroup = false;
+				groupedResults.unshift({ description: firstDescription, header: true});
+
+				var headerIndex = groupedResults.findIndex(function (result) { return result.firstInGroup; });
+				if (headerIndex > -1) {
+					var headerDescription = groupedResults[headerIndex].uniqueIdentifier ? groupedResults[headerIndex].subjectCode + " Courses" : "Non-Courses";
+					groupedResults.splice(headerIndex, 0, { description: headerDescription, header: true });
+				}
+
 				groupedResults.push({ description: "Suggest a Course ...", suggestACourse: true });
 				return groupedResults;
 			}

--- a/app/teachingCall/teachingCallForm/controllers/TeachingCallFormCtrl.js
+++ b/app/teachingCall/teachingCallForm/controllers/TeachingCallFormCtrl.js
@@ -67,21 +67,10 @@ class TeachingCallFormCtrl {
 				}
 			});
 
-			// Display courses already on the schedule
+			var results = [];
 			if (!query || query.length == 0) {
-				var courses = angular.copy(uniquePreferenceOptions);
-				var groupedResults = _.chain(courses)
-					.groupBy(function(course) { return course.subjectCode; })
-					.map(function(groupedCourses) { groupedCourses[0].firstInGroup = true; return groupedCourses; }).flatten().value();
-				groupedResults.push({ description: "Suggest a Course ...", suggestACourse: true });
-				groupedResults.unshift({ description: "Non-Courses", header: true });
-				var firstCourseIndex = groupedResults.findIndex(function (result) { return result.uniqueIdentifier; });
-				var firstSubjectCode = groupedResults[firstCourseIndex].subjectCode;
-				groupedResults.splice(firstCourseIndex, 0, { description: firstSubjectCode + " Courses", header: true });
-				return groupedResults;
+				results = angular.copy(uniquePreferenceOptions);
 			}
-
-			var optimizedQuery = $scope.optimizeQueryFormat(query);
 
 			if (query.length >= 3) {
 				var options = {
@@ -96,29 +85,30 @@ class TeachingCallFormCtrl {
 						"description"
 					]
 				};
+				var optimizedQuery = $scope.optimizeQueryFormat(query);
 
 				var fuse = new Fuse(uniquePreferenceOptions, options);
-				var results = fuse.search(optimizedQuery);
-
-				results = angular.copy(results);
-				var groupedResults = _.chain(results)
-					.groupBy(function(result) { return result.subjectCode; })
-					.map(function(groupedCourses) { groupedCourses[0].firstInGroup = true; return groupedCourses; }).flatten().value();
-
-				// Inject group headers
-				var firstDescription = groupedResults[0].uniqueIdentifier ? groupedResults[0].subjectCode + " Courses" : "Non-Courses";
-				groupedResults[0].firstInGroup = false;
-				groupedResults.unshift({ description: firstDescription, header: true});
-
-				var headerIndex = groupedResults.findIndex(function (result) { return result.firstInGroup; });
-				if (headerIndex > -1) {
-					var headerDescription = groupedResults[headerIndex].uniqueIdentifier ? groupedResults[headerIndex].subjectCode + " Courses" : "Non-Courses";
-					groupedResults.splice(headerIndex, 0, { description: headerDescription, header: true });
-				}
-
-				groupedResults.push({ description: "Suggest a Course ...", suggestACourse: true });
-				return groupedResults;
+				var searchResults = fuse.search(optimizedQuery);
+				results = angular.copy(searchResults);
 			}
+
+			// Inject headers into results for displaying in typeahead dropdown
+			var groupedResults = _.chain(results).groupBy(function (course) { return course.subjectCode; })
+				.map(function (groupedCourses) { groupedCourses[0].firstInGroup = true; return groupedCourses; })
+				.flatten().value();
+
+			var resultsWithHeaders = angular.copy(groupedResults);
+			var headersAdded = 0;
+			groupedResults.forEach(function (result, index) {
+				if (result.firstInGroup === true) {
+					var headerDescription = result.uniqueIdentifier ? result.subjectCode + " Courses" : "Non-Courses";
+					resultsWithHeaders.splice(index + headersAdded, 0, { description: headerDescription, header: true });
+					headersAdded += 1;
+				}
+			});
+			resultsWithHeaders.push({ description: "Suggest a Course ...", suggestACourse: true });
+
+			return resultsWithHeaders;
 		};
 
 		// Will improve query formatting when possible to improve search score

--- a/app/teachingCall/teachingCallForm/templates/TeachingCallForm.html
+++ b/app/teachingCall/teachingCallForm/templates/TeachingCallForm.html
@@ -124,7 +124,7 @@
 									typeahead-focus-first="false"
 									typeahead-min-length="0"
 									typeahead-focus-on-select="false"
-									typeahead-template-url="typeahead-item.html"
+									typeahead-popup-template-url="typeahead-popup-template.html"
 									auto-close="always"
 									typeahead-on-select="addPreference($item, term.termCode, isBuyout, isSabbatical, isInResidence, isWorkLifeBalance, isLeaveOfAbsence, isSabbaticalInResidence, isCourseRelease)"
 									class="form-control search-course-input">
@@ -275,9 +275,30 @@
 
 <script type="text/ng-template" id="typeahead-item.html">
 	<div class="typeahead-group-header" ng-if="match.model.firstInGroup">{{match.model.subjectCode ? match.model.subjectCode + " Courses" : "Non-Courses"}} </div>
-	<div class="typeahead--suggest-course" ng-if="match.model.suggestACourse"></div>
 	
 	<a>
 		<span ng-bind-html="match.label | uibTypeaheadHighlight:query"></span>
 	</a>
+</script>
+
+<script type="text/ng-template" id="typeahead-popup-template.html">
+		<ul class="dropdown-menu" 
+				ng-show="isOpen() && !moveInProgress" 
+				ng-style="{top: position().top+'px', left: position().left+'px'}"
+				style="top: 456px; left: 234px;" role="listbox" aria-hidden="false">
+
+			<li class="uib-typeahead-match"
+					ng-repeat="match in matches track by $index"
+					ng-class="{active: isActive($index) }"
+					ng-mouseenter="selectActive($index)"
+					ng-click="selectMatch($index)"
+					role="option"
+					id="{{::match.id}}">
+
+			<div class="typeahead-group-header" ng-if="match.model.firstInGroup">{{match.model.subjectCode ? match.model.subjectCode + " Courses" : "Non-Courses"}}</div>
+
+				<div uib-typeahead-match index="$index" match="match" query="query" template-url="templateUrl"></div>
+			</li>
+		</ul>
+	</div>
 </script>

--- a/app/teachingCall/teachingCallForm/templates/TeachingCallForm.html
+++ b/app/teachingCall/teachingCallForm/templates/TeachingCallForm.html
@@ -124,7 +124,7 @@
 									typeahead-focus-first="false"
 									typeahead-min-length="0"
 									typeahead-focus-on-select="false"
-									typeahead-popup-template-url="typeahead-popup-template.html"
+									typeahead-template-url="typeahead-item.html"
 									auto-close="always"
 									typeahead-on-select="addPreference($item, term.termCode, isBuyout, isSabbatical, isInResidence, isWorkLifeBalance, isLeaveOfAbsence, isSabbaticalInResidence, isCourseRelease)"
 									class="form-control search-course-input">
@@ -264,6 +264,7 @@
 		padding: 3px 20px;
 		border-bottom: 1px solid #999;
 		font-weight: bold;
+		cursor: default;
 	}
 
 	.typeahead--suggest-course {
@@ -274,31 +275,9 @@
 </style>
 
 <script type="text/ng-template" id="typeahead-item.html">
-	<div class="typeahead-group-header" ng-if="match.model.firstInGroup">{{match.model.subjectCode ? match.model.subjectCode + " Courses" : "Non-Courses"}} </div>
-	
-	<a>
+	<div class="typeahead-group-header" ng-if="match.model.header" ng-click="$event.stopPropagation();">{{ match.model.description }}</div>
+	<div class="typeahead--suggest-course" ng-if="match.model.suggestACourse"></div>
+	<a ng-if="!match.model.header">
 		<span ng-bind-html="match.label | uibTypeaheadHighlight:query"></span>
 	</a>
-</script>
-
-<script type="text/ng-template" id="typeahead-popup-template.html">
-		<ul class="dropdown-menu" 
-				ng-show="isOpen() && !moveInProgress" 
-				ng-style="{top: position().top+'px', left: position().left+'px'}"
-				style="top: 456px; left: 234px;" role="listbox" aria-hidden="false">
-
-			<li class="uib-typeahead-match"
-					ng-repeat="match in matches track by $index"
-					ng-class="{active: isActive($index) }"
-					ng-mouseenter="selectActive($index)"
-					ng-click="selectMatch($index)"
-					role="option"
-					id="{{::match.id}}">
-
-			<div class="typeahead-group-header" ng-if="match.model.firstInGroup">{{match.model.subjectCode ? match.model.subjectCode + " Courses" : "Non-Courses"}}</div>
-
-				<div uib-typeahead-match index="$index" match="match" query="query" template-url="templateUrl"></div>
-			</li>
-		</ul>
-	</div>
 </script>


### PR DESCRIPTION
Issue: https://trello.com/c/jP7xjKip/1997-teaching-call-suggest-a-course-dropdown-highlight-has-behavior-issues
Backend PR: https://github.com/ucdavis/ipa-web/pull/268

The header text was in the same li as the first selectable item. Inject headers into the typeahead data array to prevent highlight.