### PR TITLE
Add undergrad and grad SCH categories in summary

### DIFF
--- a/app/budget/directives/budgetSummary/budgetSummary.css
+++ b/app/budget/directives/budgetSummary/budgetSummary.css
@@ -62,3 +62,7 @@
 	align-items: center;
 	justify-content: flex-end;
 }
+
+.budget-summary__total-sch {
+	border-top: 1px solid black;
+}

--- a/app/budget/directives/budgetSummary/budgetSummary.html
+++ b/app/budget/directives/budgetSummary/budgetSummary.html
@@ -251,6 +251,44 @@
 				</td>
 			</tr>
 
+			<!-- Undergrad SCH-->
+			<tr>
+				<td>
+					<div class="budget-summary__cell-container budget-summary__cell-container--left">
+						Student Credit Hours (Undergrad)
+					</div>
+				</td>
+				<td ng-repeat="term in summary.terms" class="budget-summary__total-sch">
+					<div class="budget-summary__cell-container">
+						{{ summary.byTerm[term].undergradSCH }}
+					</div>
+				</td>
+				<td class="budget-summary__total-sch">
+					<div class="budget-summary__cell-container budget-summary__cell-container--last">
+						{{ summary.combinedTerms.undergradSCH }}
+					</div>
+				</td>
+			</tr>
+
+			<!-- Grad SCH-->
+			<tr>
+				<td>
+					<div class="budget-summary__cell-container budget-summary__cell-container--left">
+						Student Credit Hours (Graduate)
+					</div>
+				</td>
+				<td ng-repeat="term in summary.terms">
+					<div class="budget-summary__cell-container">
+						{{ summary.byTerm[term].gradSCH }}
+					</div>
+				</td>
+				<td>
+					<div class="budget-summary__cell-container budget-summary__cell-container--last">
+						{{ summary.combinedTerms.gradSCH }}
+					</div>
+				</td>
+			</tr>
+
 			<!-- Total Student Credit Hours -->
 			<tr>
 				<td>

--- a/app/budget/services/actions/budgetCalculations.js
+++ b/app/budget/services/actions/budgetCalculations.js
@@ -485,6 +485,8 @@ class BudgetCalculations {
 					funds: 0,
 					balance: 0,
 					totalSCH: 0,
+					gradSCH: 0,
+					undergradSCH: 0,
 					lowerDivCount: 0,
 					upperDivCount: 0,
 					graduateCount: 0,
@@ -507,6 +509,8 @@ class BudgetCalculations {
 						},
 						totalCosts: 0,
 						totalSCH: 0,
+						gradSCH: 0,
+						undergradSCH: 0,
 						lowerDivCount: 0,
 						upperDivCount: 0,
 						graduateCount: 0,
@@ -537,6 +541,12 @@ class BudgetCalculations {
 								units = sectionGroupCost.unitsLow;
 							}
 
+							if (sectionGroupCost.courseNumber >= 200) {
+								summary.byTerm[term].gradSCH += (sectionGroupCost.enrollment || 0) * (sectionGroupCost.unitsLow || 0);
+							} else {
+								summary.byTerm[term].undergradSCH += (sectionGroupCost.enrollment || 0) * (sectionGroupCost.unitsLow || 0);
+							}
+
 							summary.byTerm[term].totalUnits += units;
 							summary.byTerm[term].totalSCH += (sectionGroupCost.enrollment || 0) * (sectionGroupCost.unitsLow || 0);
 							summary.byTerm[term].lowerDivCount += (parseInt(sectionGroupCost.courseNumber) < 100 ? 1 : 0);
@@ -558,6 +568,8 @@ class BudgetCalculations {
 					summary.combinedTerms.totalCosts += summary.byTerm[term].totalCosts;
 					summary.combinedTerms.totalUnits += summary.byTerm[term].totalUnits;
 					summary.combinedTerms.totalSCH += summary.byTerm[term].totalSCH;
+					summary.combinedTerms.gradSCH += summary.byTerm[term].gradSCH;
+					summary.combinedTerms.undergradSCH += summary.byTerm[term].undergradSCH;
 					summary.combinedTerms.lowerDivCount += summary.byTerm[term].lowerDivCount;
 					summary.combinedTerms.upperDivCount += summary.byTerm[term].upperDivCount;
 					summary.combinedTerms.graduateCount += summary.byTerm[term].graduateCount;


### PR DESCRIPTION
Issue:
https://trello.com/c/5MZjjJQ5/1880-1-budget-summary-tab-should-break-out-undergraduate-sch-separate-from-graduate-sch