### PR TITLE
Bugfix/workgroup switcher size

### DIFF
--- a/app/shared/css/shared.css
+++ b/app/shared/css/shared.css
@@ -225,6 +225,7 @@ table.availability-grid tr td {
 .ipa-header .header--work-group .dropdown-toggle {
 	font-size: 12px;
 	padding: 6px 12px 6px 12px;
+	height: 31px;
 }
 
 .ipa-header .header--work-group .dropdown-menu li i {


### PR DESCRIPTION
Issue: https://trello.com/c/fraZzXYU/54-workgroup-year-switcher-can-get-needlessly-cramped

Before
![screen shot 2018-12-19 at 10 53 03 am](https://user-images.githubusercontent.com/13262189/50246448-3de07080-038a-11e9-889f-27c373adfd83.png)

After
![screen shot 2018-12-19 at 12 34 56 pm](https://user-images.githubusercontent.com/13262189/50246547-87c95680-038a-11e9-93b2-2906b63f7b2e.png)
