### PR TITLE
Bugfix: when navigating to a year without a teaching call, should display a message

### DIFF
--- a/app/teachingCall/teachingCallForm/controllers/TeachingCallFormCtrl.js
+++ b/app/teachingCall/teachingCallForm/controllers/TeachingCallFormCtrl.js
@@ -20,7 +20,6 @@ class TeachingCallFormCtrl {
 
 		$rootScope.$on('teachingCallFormStateChanged', function (event, data) {
 			$scope.view.state = data;
-			console.log(data);
 		});
 
 		$rootScope.$on('sharedStateSet', function (event, data) {

--- a/app/teachingCall/teachingCallForm/controllers/TeachingCallFormCtrl.js
+++ b/app/teachingCall/teachingCallForm/controllers/TeachingCallFormCtrl.js
@@ -20,6 +20,11 @@ class TeachingCallFormCtrl {
 
 		$rootScope.$on('teachingCallFormStateChanged', function (event, data) {
 			$scope.view.state = data;
+			console.log(data);
+		});
+
+		$rootScope.$on('sharedStateSet', function (event, data) {
+			$scope.sharedState = data;
 		});
 
 		$scope.viewState = {

--- a/app/teachingCall/teachingCallForm/templates/TeachingCallForm.html
+++ b/app/teachingCall/teachingCallForm/templates/TeachingCallForm.html
@@ -18,6 +18,15 @@
 		</tutorial-modal>
   </ipa-modal>
 
+	<!-- handle lack of access -->
+	<div ng-if="view.state && !view.state.teachingCallReceiptId">
+		<div class="jumbotron" style="text-align: center; height: 100%; background-color: white;">
+			<p class="lead">You have not been invited to a teaching call for the year {{ year }}-{{ nextYear }}.</p>
+			<br />
+			<p class="lead">If you feel this is in error please contact the Academic Planner for {{ sharedState.workgroup.name }}.</p>
+		</div>
+	</div>
+
 	<div id="teaching-call-form--container" ng-repeat="term in view.state.terms" ng-if="term.termCode == view.state.selectedTermCode">
 		<!-- course preferences -->
 		<div id="teaching-call--course-preference" class="row">


### PR DESCRIPTION
Issue:
https://trello.com/c/X8rIm4ZV/1941-tc-if-you-go-to-a-valid-year-that-you-were-called-for-then-use-the-year-selector-to-select-a-different-year-you-can-wind-up-with