### PR TITLE
Budget: Add instructor type count to summary view

### DIFF
--- a/app/budget/directives/budgetSummary/budgetSummary.html
+++ b/app/budget/directives/budgetSummary/budgetSummary.html
@@ -130,12 +130,12 @@
 				</td>
 				<td ng-repeat="term in summary.terms">
 					<div class="budget-summary__cell-container">
-						{{ toCurrency(summary.byTerm[term].replacementCosts.byInstructorTypeId[instructorTypeId]) }}
+						{{ toCurrency(summary.byTerm[term].replacementCosts.byInstructorTypeId[instructorTypeId]) }} ({{ summary.byTerm[term].replacementCosts.instructorTypeCount[instructorTypeId] || 0 }})
 					</div>
 				</td>
 				<td>
 					<div class="budget-summary__cell-container budget-summary__cell-container--last">
-						{{ toCurrency(summary.combinedTerms.replacementCosts.byInstructorTypeId[instructorTypeId]) }}
+						{{ toCurrency(summary.combinedTerms.replacementCosts.byInstructorTypeId[instructorTypeId]) }} ({{ summary.combinedTerms.replacementCosts.instructorTypeCount[instructorTypeId] || 0 }})
 					</div>
 				</td>
 			</tr>

--- a/app/budget/services/actions/budgetCalculations.js
+++ b/app/budget/services/actions/budgetCalculations.js
@@ -479,7 +479,8 @@ class BudgetCalculations {
 					replacementCosts: {
 						overall: 0,
 						instructorTypeIds: [],
-						byInstructorTypeId: {}
+						byInstructorTypeId: {},
+						instructorTypeCount: {}
 					},
 					totalCosts: 0,
 					funds: 0,
@@ -505,7 +506,8 @@ class BudgetCalculations {
 						replacementCosts: {
 							overall: 0,
 							instructorTypeIds: [],
-							byInstructorTypeId: {}
+							byInstructorTypeId: {},
+							instructorTypeCount: {},
 						},
 						totalCosts: 0,
 						totalSCH: 0,
@@ -612,6 +614,9 @@ class BudgetCalculations {
 	
 				if (index == -1) {
 					replacementCosts.instructorTypeIds.push(instructorTypeId);
+					replacementCosts.instructorTypeCount[instructorTypeId] = 1;
+				} else {
+					replacementCosts.instructorTypeCount[instructorTypeId] += 1;
 				}
 	
 				replacementCosts.byInstructorTypeId[instructorTypeId] = replacementCosts.byInstructorTypeId[instructorTypeId] || 0;
@@ -627,6 +632,9 @@ class BudgetCalculations {
 					var index = replacementCosts.instructorTypeIds.indexOf(instructorTypeId);
 					if (index == -1) {
 						replacementCosts.instructorTypeIds.push(instructorTypeId);
+						replacementCosts.instructorTypeCount[instructorTypeId] = 1;
+					} else {
+						replacementCosts.instructorTypeCount[instructorTypeId] += 1;
 					}
 		
 					// Ensure not null (un-initialized)


### PR DESCRIPTION
Issue: https://trello.com/c/ElTFPpcg/2018-add-instructor-type-counts-next-to-the-cost-breakdowns-on-the-budget-module-summary-screen