### PR TITLE
bugfix/workload summary calculation differences

### DIFF
--- a/app/workloadSummaryReport/directives/workloadTotals/workloadTotals.css
+++ b/app/workloadSummaryReport/directives/workloadTotals/workloadTotals.css
@@ -1,5 +1,5 @@
 .workload-totals__content {
-	padding-bottom: 20px;
+	padding-bottom: 5px;
 	padding-left: 20px;
 	padding-right: 20px;
 }
@@ -26,4 +26,11 @@
 	padding-bottom: 5px;
 	padding-left: 20px;
 	font-size: 12px;
+}
+
+.workload-totals__warning {
+	font-size: 10px;
+	padding-bottom: 20px;
+	padding-left: 20px;
+	color: gray;
 }

--- a/app/workloadSummaryReport/directives/workloadTotals/workloadTotals.html
+++ b/app/workloadSummaryReport/directives/workloadTotals/workloadTotals.html
@@ -1,6 +1,6 @@
 <div class="workload-totals">
 	<div class="workload-totals__header">
-		Totals
+		Assignment Totals
 	</div>
 	<div class="workload-totals__content">
 		<table class="workload-table__table">
@@ -72,4 +72,13 @@
 			</tbody>
 		</table>
 	</div>
+	<div class="workload-totals__warning">
+		<div>
+			Enrollment, previous enrollment and SCH are based on classes with instructor assignments.
+		</div>
+		<div>
+			Calculations that include classes without assignments (or with generic instructor type assignments) can be found in the budget summary report.
+		</div>
+	</div>
+
 </div>

--- a/app/workloadSummaryReport/services/workloadSummaryActions.js
+++ b/app/workloadSummaryReport/services/workloadSummaryActions.js
@@ -64,12 +64,15 @@ class WorkloadSummaryActions {
 				WorkloadSummaryService.getSections(workgroupId, year).then(function (rawSections) {
 					let sections = {
 						ids: [],
-						list: {}
+						list: {},
+						bySectionGroupId: {}
 					};
 
 					rawSections.forEach(function(section) {
 						sections.ids.push(section.id);
 						sections.list[section.id] = section;
+						sections.bySectionGroupId[section.sectionGroupId] = sections.bySectionGroupId[section.sectionGroupId] || [];
+						sections.bySectionGroupId[section.sectionGroupId].push(section);
 					});
 
 					WorkloadSummaryReducers.reduce({
@@ -341,12 +344,20 @@ class WorkloadSummaryActions {
 						if (teachingAssignment.sectionGroupId > 0) {
 							assignment.sequencePattern = course.sequencePattern;
 							assignment.enrollment = _self._getEnrollment(sectionGroup);
+
 							assignment.actualEnrollment = sectionGroup.actualEnrollment;
 							assignment.maxEnrollment = sectionGroup.maxEnrollment;
+
+							var seats = 0;
+							WorkloadSummaryReducers._state.sections.bySectionGroupId[sectionGroup.id].forEach(function(section) {
+								seats += section.seats;
+							});
+
+							assignment.seats = seats;
 							assignment.previousEnrollment = sectionGroup.previousEnrollment;
 							assignment.enrollmentPercentage = assignment.maxEnrollment && assignment.actualEnrollment ? parseInt((assignment.actualEnrollment / assignment.maxEnrollment) * 100) : "0";
 							assignment.units = _self._getUnits(course);
-							assignment.studentCreditHours = assignment.enrollment * assignment.units;
+							assignment.studentCreditHours = assignment.seats * assignment.units;
 
 							calculatedView.totals.assignmentCount += 1;
 							calculatedView.totals.enrollment += assignment.enrollment;

--- a/app/workloadSummaryReport/services/workloadSummaryActions.js
+++ b/app/workloadSummaryReport/services/workloadSummaryActions.js
@@ -350,9 +350,13 @@ class WorkloadSummaryActions {
 
 							var seats = 0;
 
-							WorkloadSummaryReducers._state.sections.bySectionGroupId[sectionGroup.id].forEach(function(section) {
-								seats += section.seats;
-							});
+							var sections = WorkloadSummaryReducers._state.sections.bySectionGroupId[sectionGroup.id];
+
+							if (sections) {
+								sections.forEach(function(section) {
+									seats += section.seats;
+								});
+							}
 
 							assignment.seats = seats;
 							assignment.previousEnrollment = sectionGroup.previousEnrollment;

--- a/app/workloadSummaryReport/services/workloadSummaryActions.js
+++ b/app/workloadSummaryReport/services/workloadSummaryActions.js
@@ -349,6 +349,7 @@ class WorkloadSummaryActions {
 							assignment.maxEnrollment = sectionGroup.maxEnrollment;
 
 							var seats = 0;
+
 							WorkloadSummaryReducers._state.sections.bySectionGroupId[sectionGroup.id].forEach(function(section) {
 								seats += section.seats;
 							});


### PR DESCRIPTION
Issue:
https://trello.com/c/6j9ZGxyQ/2046-workload-summary-sch-calculation-should-be-using-requested-seats-not-census-count-check-all-other-sch-calculations-in-ipa