### PR TITLE
Bugfix/dropdown-height

### DIFF
--- a/app/shared/directives/ipaDropdown/ipaDropdown.css
+++ b/app/shared/directives/ipaDropdown/ipaDropdown.css
@@ -52,6 +52,8 @@
 	border: 1px solid rgba(27,31,35,0.15);
 	border-radius: 3px;
 	box-shadow: 0 3px 12px rgba(27,31,35,0.15);
+	max-height: 80vh;
+	overflow-y: scroll;
 }
 
 .ipa-dropdown .item {


### PR DESCRIPTION
Issue:
https://trello.com/c/eV1BDArk/2106-budget-dropdown-is-not-properly-scrolling-with-a-max-height-it-instead-just-extends-for-multiple-screen-lengths