### PR TITLE
Bugfix/support assignment sections order

### DIFF
--- a/app/supportAssignment/services/supportSelectors.js
+++ b/app/supportAssignment/services/supportSelectors.js
@@ -157,7 +157,7 @@ class SupportSelectors {
 					newSectionGroups.push(sectionGroup);
 				});
 	
-				var sortedSectionGroups = _array_sortByProperty(newSectionGroups, ["subjectCode", "courseNumber"]);
+				var sortedSectionGroups = _array_sortByProperty(newSectionGroups, ["subjectCode", "courseNumber", "sequencePattern"]);
 	
 				return sortedSectionGroups;
 			},


### PR DESCRIPTION
Issue: https://trello.com/c/WbX2jfEB/2101-025-support-assignments-by-course-tab-sometimes-displays-sections-out-of-order