### PR TITLE
Change placeholder text color to black on teaching call form add pref…

### DIFF
--- a/app/teachingCall/css/teaching-call-form.css
+++ b/app/teachingCall/css/teaching-call-form.css
@@ -1327,3 +1327,8 @@ table.availability-grid tr td {
 	color: white !important;
 	border-color: #03A9F4;
 }
+
+.search-course-input::placeholder {
+  color: #333;
+  opacity: 1;
+}


### PR DESCRIPTION
Issue:
https://trello.com/c/885OyfJP/2099-teaching-call-add-preference-text-should-not-be-grey-as-this-has-confused-an-instructor