### PR TITLE
Should only offer to revert for scheduled courses

### DIFF
--- a/app/budget/services/actions/scheduleCostCalculations.js
+++ b/app/budget/services/actions/scheduleCostCalculations.js
@@ -84,7 +84,7 @@ class ScheduleCostCalculations {
 
           // Calculate reversion
           // Identify a difference
-          if (sectionGroupCost.instructorId != assignedInstructorId || (assignedInstructorTypeId && sectionGroupCost.instructorTypeId != assignedInstructorTypeId)) {
+          if (sectionGroupCost.sectionGroup && sectionGroupCost.instructorId != assignedInstructorId || (assignedInstructorTypeId && sectionGroupCost.instructorTypeId != assignedInstructorTypeId)) {
             // Schedule has no assignment
             if (!assignedInstructorId && !assignedInstructorTypeId) {
               sectionGroupCost.reversionDisplayName = "no instructor";


### PR DESCRIPTION
Issue:
https://trello.com/c/WKBKT4ru/2089-budget-erroneously-displaying-reversion-for-non-scheduled-courses