### PR TITLE
Feature/add unassigned costs to budget summary

### DIFF
--- a/app/budget/directives/budgetSummary/budgetSummary.html
+++ b/app/budget/directives/budgetSummary/budgetSummary.html
@@ -146,7 +146,23 @@
 						</div>
 					</td>
 				</tr>
-
+				<tr>
+					<td>
+						<div class="budget-summary__cell-container budget-summary__cell-container--left">
+							Unassigned
+						</div>
+					</td>
+					<td ng-repeat="term in summary.terms">
+						<div class="budget-summary__cell-container">
+							{{ toCurrency(summary.byTerm[term].replacementCosts.unassignedCost) }} ({{ summary.byTerm[term].replacementCosts.unassignedCount || 0 }})
+						</div>
+					</td>
+					<td>
+						<div class="budget-summary__cell-container budget-summary__cell-container--last">
+							{{ toCurrency(summary.combinedTerms.replacementCosts.unassignedCost) }} ({{ summary.combinedTerms.replacementCosts.unassignedCount || 0 }})
+						</div>
+					</td>
+				</tr>
 					<!-- Replacement Costs -->
 					<tr>
 						<td>

--- a/app/budget/directives/budgetSummary/budgetSummary.html
+++ b/app/budget/directives/budgetSummary/budgetSummary.html
@@ -163,24 +163,24 @@
 						</div>
 					</td>
 				</tr>
-					<!-- Replacement Costs -->
-					<tr>
-						<td>
-							<div class="budget-summary__cell-container budget-summary__cell-container--left budget-summary__cell--bold">
-								Replacement Costs
-							</div>
-						</td>
-						<td ng-repeat="term in summary.terms">
-							<div class="budget-summary__cell-container budget-summary__cell--bold budget-summary__cell--total">
-								{{ toCurrency(summary.byTerm[term].replacementCosts.overall) }}
-							</div>
-						</td>
-						<td>
-							<div class="budget-summary__cell-container budget-summary__cell-container--last budget-summary__cell--bold budget-summary__cell--total">
-								{{ toCurrency(summary.combinedTerms.replacementCosts.overall) }}
-							</div>
-						</td>
-					</tr>
+				<!-- Replacement Costs -->
+				<tr>
+					<td>
+						<div class="budget-summary__cell-container budget-summary__cell-container--left budget-summary__cell--bold">
+							Replacement Costs
+						</div>
+					</td>
+					<td ng-repeat="term in summary.terms">
+						<div class="budget-summary__cell-container budget-summary__cell--bold budget-summary__cell--total">
+							{{ toCurrency(summary.byTerm[term].replacementCosts.overall) }}
+						</div>
+					</td>
+					<td>
+						<div class="budget-summary__cell-container budget-summary__cell-container--last budget-summary__cell--bold budget-summary__cell--total">
+							{{ toCurrency(summary.combinedTerms.replacementCosts.overall) }}
+						</div>
+					</td>
+				</tr>
 				<!-- Total Costs -->
 				<tr>
 					<td>

--- a/app/budget/services/actions/budgetCalculations.js
+++ b/app/budget/services/actions/budgetCalculations.js
@@ -592,18 +592,27 @@ class BudgetCalculations {
 
         var instructorTypeId = null;
 
-        if (sectionGroup.overrideInstructorTypeId) {
-          instructorTypeId = sectionGroup.overrideInstructorTypeId;
-        } else if (sectionGroup.instructor && sectionGroup.instructor.instructorType && sectionGroup.instructor.instructorType.id) {
-          instructorTypeId = sectionGroup.instructor.instructorType.id;
-        } else {
-          instructorTypeId = sectionGroup.instructorTypeId;
-        }
+				if (sectionGroup.overrideInstructorTypeId) {
+					instructorTypeId = sectionGroup.overrideInstructorTypeId;
+				} else if (sectionGroup.instructor && sectionGroup.instructor.instructorType && sectionGroup.instructor.instructorType.id) {
+					instructorTypeId = sectionGroup.instructor.instructorType.id;
+				} else {
+					instructorTypeId = sectionGroup.instructorTypeId;
+				}
 
 				var instructor = BudgetReducers._state.assignedInstructors.list[sectionGroup.instructorId] || BudgetReducers._state.activeInstructors.list[sectionGroup.instructorId];
 
-				// Course has a cost but no instructor
-				if (!instructorTypeId && !instructor) { return replacementCosts; }
+				// Course has no instructor
+				if (!instructorTypeId && !instructor) {
+					if (!replacementCost) { return replacementCosts; }
+
+					replacementCosts.unassignedCost = replacementCosts.unassignedCost || 0;
+					replacementCosts.unassignedCost += replacementCost;
+					replacementCosts.unassignedCount = replacementCosts.unassignedCount || 0;
+					replacementCosts.unassignedCount += 1;
+
+					return replacementCosts;
+				}
 
 				if (!instructorTypeId) {
 					instructorTypeId = this._calculateInstructorType(instructor.id).id;

--- a/app/budget/services/actions/budgetCalculations.js
+++ b/app/budget/services/actions/budgetCalculations.js
@@ -481,7 +481,9 @@ class BudgetCalculations {
 						overall: 0,
 						instructorTypeIds: [],
 						byInstructorTypeId: {},
-						instructorTypeCount: {}
+						instructorTypeCount: {},
+						unassignedCost: 0,
+						unassignedCount: 0
 					},
 					totalCosts: 0,
 					funds: 0,
@@ -568,6 +570,9 @@ class BudgetCalculations {
 					summary.combinedTerms.supportCosts += summary.byTerm[term].supportCosts;
 					summary.combinedTerms.replacementCosts.overall += summary.byTerm[term].replacementCosts.overall;
 					summary.combinedTerms.replacementCosts = _self._combineReplacementCost(summary.combinedTerms.replacementCosts, summary.byTerm[term].replacementCosts);
+					summary.combinedTerms.replacementCosts.unassignedCost += summary.byTerm[term].replacementCosts.unassignedCost || 0;
+					summary.combinedTerms.replacementCosts.unassignedCount += summary.byTerm[term].replacementCosts.unassignedCount || 0;
+
 					summary.combinedTerms.totalCosts += summary.byTerm[term].totalCosts;
 					summary.combinedTerms.totalUnits += summary.byTerm[term].totalUnits;
 					summary.combinedTerms.totalSCH += summary.byTerm[term].totalSCH;


### PR DESCRIPTION
Issue:
https://trello.com/c/KppFQ465/2120-budget-add-unassigned-instructortype-category-in-budget-summary-so-when-an-instructorcost-is-set-but-no-instructor-that-cost-is